### PR TITLE
Minor bug fixing 17 08 22

### DIFF
--- a/src/Core/Model.php
+++ b/src/Core/Model.php
@@ -135,55 +135,53 @@ class Model
 			// count join
 			$this->total_filtered = \Kyte\Core\DBI::count($this->kyte_model['name'], $sql, $join);
 
-			if (isset($order)) {
-				if (!empty($order)) {
-					$order_sql = ' ORDER BY ';
-					for($i = 0; $i < count($order); $i++) {
-						if (isset($order[$i]['field'], $order[$i]['direction'])) {
-							$direction = strtoupper($order[$i]['direction']);
-							if ($direction == 'ASC' || $direction == 'DESC') {
-								$f = explode(".", $order[$i]['field']);
-								if (count($f) == 1) {
-									$order_sql .= " `$main_tbl`.`{$order[$i]['field']}` {$direction}";
-								} else if (count($f) == 2) {
-									// get struct for FK
-									$fk_attr = $this->kyte_model['struct'][$f[0]];
-									// capitalize the first letter for table name
-									$tblName = $fk_attr['fk']['model'];
-									$order_sql .= " `$tblName`.`{$f[1]}` {$direction}";
+			if (!empty($order)) {
+                $order_sql = ' ORDER BY ';
+                for($i = 0; $i < count($order); $i++) {
+                    if (isset($order[$i]['field'], $order[$i]['direction'])) {
+                        $direction = strtoupper($order[$i]['direction']);
+                        if ($direction == 'ASC' || $direction == 'DESC') {
+                            $f = explode(".", $order[$i]['field']);
+                            if (count($f) == 1) {
+                                $order_sql .= " `$main_tbl`.`{$order[$i]['field']}` {$direction}";
+                            } else if (count($f) == 2) {
+                                // get struct for FK
+                                $fk_attr = $this->kyte_model['struct'][$f[0]];
+                                // capitalize the first letter for table name
+                                $tblName = $fk_attr['fk']['model'];
+                                $order_sql .= " `$tblName`.`{$f[1]}` {$direction}";
 
-									// prepare join statement
+                                // prepare join statement
 
-									// if join is null, initialize with empty array
-									if (!$join) {
-										$join = [];
-									}
+                                // if join is null, initialize with empty array
+                                if (!$join) {
+                                    $join = [];
+                                }
 
-									$found = false;
-									foreach($join as $j) {
-										if ($j['table'] == $tblName) {
-											$found = true;
-											break;
-										}
-									}
-									if (!$found) {
-										$join[] = [
-											'table' => $tblName,
-											'main_table_idx' => $f[0],
-											'table_idx' => $fk_attr['fk']['field'],
-										];
-									}
-								} else {
-									throw new \Exception("Unsupported field depth {$order[$i]['field']}");
-								}
-								if ($i < (count($order) - 1)) {
-									$order_sql .= ', ';
-								}
-							}
-						}
-					}
-					$sql .= $order_sql;
-				}
+                                $found = false;
+                                foreach($join as $j) {
+                                    if ($j['table'] == $tblName) {
+                                        $found = true;
+                                        break;
+                                    }
+                                }
+                                if (!$found) {
+                                    $join[] = [
+                                        'table' => $tblName,
+                                        'main_table_idx' => $f[0],
+                                        'table_idx' => $fk_attr['fk']['field'],
+                                    ];
+                                }
+                            } else {
+                                throw new \Exception("Unsupported field depth {$order[$i]['field']}");
+                            }
+                            if ($i < (count($order) - 1)) {
+                                $order_sql .= ', ';
+                            }
+                        }
+                    }
+                }
+                $sql .= $order_sql;
 			} else {
 				$sql .= " ORDER BY `$main_tbl`.`date_created` DESC";
 			}
@@ -243,7 +241,7 @@ class Model
 			}
 
 			$data = \Kyte\Core\DBI::group($this->kyte_model['name'], $field, $sql);
-			
+
 			return $data;
 
 		} catch (\Exception $e) {
@@ -256,7 +254,7 @@ class Model
 	{
 		try {
 			$data = \Kyte\Core\DBI::query($sql);
-			
+
 			return $data;
 
 		} catch (\Exception $e) {
@@ -272,7 +270,7 @@ class Model
 			$data = array();
 
 			if (isset($fields, $values)) {
-				
+
 				if (!$all) {
 					$sql = "WHERE (";
 				} else {
@@ -293,7 +291,7 @@ class Model
 				if (!$all) {
 					$sql .= ") AND `deleted` = '0'";
 				}
-				
+
 				$data = \Kyte\Core\DBI::select($this->kyte_model['name'], null, $sql);
 			} else {
 				$data = $all ? \Kyte\Core\DBI::select($this->kyte_model['name'], null, null) : \Kyte\Core\DBI::select($this->kyte_model['name'], null, "WHERE `deleted` = '0'");

--- a/src/Core/Model.php
+++ b/src/Core/Model.php
@@ -137,6 +137,11 @@ class Model
 
 			if (!empty($order)) {
                 $order_sql = ' ORDER BY ';
+                //Hack to check if something has been added to the ORDER BY sentence by using string length instead of
+                //a syntax check which is costly
+                $originalOrderByStatementLen = strlen($order_sql);
+
+                //Order field will work if formatted on a multidimensional array, this allows order combining
                 for($i = 0; $i < count($order); $i++) {
                     if (isset($order[$i]['field'], $order[$i]['direction'])) {
                         $direction = strtoupper($order[$i]['direction']);
@@ -181,7 +186,13 @@ class Model
                         }
                     }
                 }
-                $sql .= $order_sql;
+                //Hack: Check if something has been added to the ORDER BY sentence by string length otherwise we can get
+                //a MySQL syntax error, example: ... ORDER BY (empty string here); if you pass the order parameter as
+                //an unidimensional array ['field' => 'category', 'direction' => 'asc'] would crash otherwise
+                if(strlen($order_sql) > $originalOrderByStatementLen){
+                    $sql .= $order_sql;
+                }
+
 			} else {
 				$sql .= " ORDER BY `$main_tbl`.`date_created` DESC";
 			}

--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -46,9 +46,9 @@ class ModelTest extends TestCase
                     'size'		=> 255,
                     'date'		=> false,
                 ],
-        
+
                 // framework attributes
-        
+
                 'kyte_account'	=> [
                     'type'		=> 'i',
                     'required'	=> true,
@@ -56,45 +56,45 @@ class ModelTest extends TestCase
                     'unsigned'	=> true,
                     'date'		=> false,
                 ],
-        
+
                 // audit attributes
-        
+
                 'created_by'		=> [
                     'type'		=> 'i',
                     'required'	=> false,
                     'date'		=> true,
                 ],
-        
+
                 'date_created'		=> [
                     'type'		=> 'i',
                     'required'	=> false,
                     'date'		=> true,
                 ],
-        
+
                 'modified_by'		=> [
                     'type'		=> 'i',
                     'required'	=> false,
                     'date'		=> true,
                 ],
-        
+
                 'deleted_by'		=> [
                     'type'		=> 'i',
                     'required'	=> false,
                     'date'		=> true,
                 ],
-        
+
                 'created_by'		=> [
                     'type'		=> 'i',
                     'required'	=> false,
                     'date'		=> true,
                 ],
-        
+
                 'date_deleted'		=> [
                     'type'		=> 'i',
                     'required'	=> false,
                     'date'		=> true,
                 ],
-        
+
                 'deleted'	=> [
                     'type'		=> 'i',
                     'required'	=> false,
@@ -107,7 +107,7 @@ class ModelTest extends TestCase
         ];
 
         define('TestTable', $TestTable);
-        
+
         $this->assertTrue(\Kyte\Core\DBI::createTable(TestTable));
 
         // create entry
@@ -118,23 +118,23 @@ class ModelTest extends TestCase
             'temperature' => 78.3,
             'kyte_account' => 1,
         ]));
-    
+
         // test retrieve
         $model = new \Kyte\Core\ModelObject(TestTable);
         $this->assertTrue($model->retrieve('name', 'Test'));
-    
+
         // test retrieve with conditions
         $model = new \Kyte\Core\ModelObject(TestTable);
         $this->assertTrue($model->retrieve('name', 'Test', [['field' => 'category', 'value' => 'test']]));
-    
+
         // test custom select
         $data = \Kyte\Core\DBI::select('TestTable');
         $this->assertTrue(count($data) > 0 ? true : false);
-    
+
         // test custom query
         $data = \Kyte\Core\DBI::query('* FROM `TestTable`;');
         $this->assertTrue(count($data) > 0 ? true : false);
-    
+
         // test udpate entry
         $model = new \Kyte\Core\ModelObject(TestTable);
         $this->assertTrue($model->retrieve('name', 'Test'));
@@ -144,12 +144,12 @@ class ModelTest extends TestCase
             'temperature' => 78.3,
             'kyte_account' => 1,
         ]));
-    
+
         // test retrieve and delete
         $model = new \Kyte\Core\ModelObject(TestTable);
         $this->assertTrue($model->retrieve('name', 'Test1'));
         $this->assertTrue($model->delete(null, null, 0));
-    
+
         // test delete with conditions
         $model = new \Kyte\Core\ModelObject(TestTable);
         $this->assertTrue($model->create([
@@ -159,16 +159,16 @@ class ModelTest extends TestCase
             'kyte_account' => 1,
         ]));
         $this->assertTrue($model->delete('name', 'Test2', 0));
-    
+
         // test retrieve and purge
         $model = new \Kyte\Core\ModelObject(TestTable);
         $this->assertTrue($model->retrieve('name', 'Test1', null, null, true));
         $this->assertTrue($model->purge());
-    
+
         // test purge with conditions
         $model = new \Kyte\Core\ModelObject(TestTable);
         $this->assertTrue($model->purge('name', 'Test2'));
-    
+
         // test getParam
         $model = new \Kyte\Core\ModelObject(TestTable);
         $this->assertTrue($model->create([
@@ -178,22 +178,22 @@ class ModelTest extends TestCase
             'kyte_account' => 1,
         ]));
         $this->assertEquals('Test', $model->getParam('name'));
-    
+
         // test getParams
         $model = new \Kyte\Core\ModelObject(TestTable);
         $this->assertTrue($model->retrieve('name', 'Test'));
         $this->assertArrayHasKey('category', $model->getParams(['name','category']));
-    
+
         // test getAllParams
         $model = new \Kyte\Core\ModelObject(TestTable);
         $this->assertTrue($model->retrieve('name', 'Test'));
         $this->assertArrayHasKey('category', $model->getAllParams());
-    
+
         // test getAllParams with date time format
         $model = new \Kyte\Core\ModelObject(TestTable);
         $this->assertTrue($model->retrieve('name', 'Test'));
         $this->assertArrayHasKey('category', $model->getAllParams('Y/m/d'));
-    
+
         // test get paramKeys
         $model = new \Kyte\Core\ModelObject(TestTable);
         $this->assertTrue($model->retrieve('name', 'Test'));
@@ -201,9 +201,9 @@ class ModelTest extends TestCase
 
         /*
         * Model tests
-        * 
+        *
         * */
-    
+
         // test retrieve
         // create one more entry
         $model = new \Kyte\Core\ModelObject(TestTable);
@@ -216,12 +216,12 @@ class ModelTest extends TestCase
         $model = new \Kyte\Core\Model(TestTable);
         $this->assertTrue($model->retrieve('category', 'Test'));
         $this->assertEquals(2, $model->count());
-    
+
         // test retrieve with conditions
         $model = new \Kyte\Core\Model(TestTable);
         $this->assertTrue($model->retrieve('category', 'Test', false, [['field' => 'name', 'value' => 'Test2']]));
         $this->assertEquals(1, $model->count());
-    
+
         // test delete then retrieve all
         $model = new \Kyte\Core\ModelObject(TestTable);
         // create and delete
@@ -235,60 +235,60 @@ class ModelTest extends TestCase
         $model = new \Kyte\Core\Model(TestTable);
         $this->assertTrue($model->retrieve('category', 'Test', false, null, true));
         $this->assertEquals(3, $model->count());
-    
+
         // test retrieve order by
         $model = new \Kyte\Core\Model(TestTable);
         $this->assertTrue($model->retrieve('category', 'Test', false, null, true, ['field' => 'category', 'direction' => 'asc']));
         $this->assertEquals(3, $model->count());
-    
+
         // test retrieve like
         $model = new \Kyte\Core\Model(TestTable);
-        $this->assertTrue($model->retrieve('name', 'Test', true,));
+        $this->assertTrue($model->retrieve('name', 'Test', true));
         $this->assertEquals(2, $model->count());
-    
+
         // test return first
         $model = new \Kyte\Core\Model(TestTable);
         $this->assertTrue($model->retrieve('category', 'Test'));
         $this->assertIsObject($model->returnFirst());
-    
+
         // test group by
         $model = new \Kyte\Core\Model(TestTable);
         $this->assertCount(1, $model->groupBy('category'));
-    
+
         // test group by with conditions
         $model = new \Kyte\Core\Model(TestTable);
         $this->assertCount(1, $model->groupBy('category', [['field' => 'category', 'value' => 'Test']]));
-    
+
         //test group by all
         $model = new \Kyte\Core\Model(TestTable);
         $this->assertCount(1, $model->groupBy('category', null, true));
-    
+
         // test custom select
         $model = new \Kyte\Core\Model(TestTable);
         $data = $model->customSelect('* FROM `TestTable`;');
         $this->assertIsArray($data);
         $this->assertCount(3, $data);
-    
+
         // test search
         $model = new \Kyte\Core\Model(TestTable);
         $this->assertTrue($model->search(['name'], ['Test']));
         $this->assertEquals(2, $model->count());
-    
+
         // test search all
         $model = new \Kyte\Core\Model(TestTable);
         $this->assertTrue($model->search(['name'], ['Test'], true));
         $this->assertEquals(3, $model->count());
-    
+
         // test retrieve from
         $model = new \Kyte\Core\Model(TestTable);
         $this->assertTrue($model->from('date_created', 0, time()));
         $this->assertEquals(0, $model->count());
-    
+
         // test retrieve from all
         $model = new \Kyte\Core\Model(TestTable);
         $this->assertTrue($model->from('date_created', 0, time(), true));
         $this->assertEquals(2, $model->count());
-    
+
         // test retrieve from all equals
         $model = new \Kyte\Core\Model(TestTable);
         $this->assertTrue($model->from('date_created', 0, time(), true, true));


### PR DESCRIPTION
Ambiguous variable check, during Unit test, minor syntax error correction, on UnitTest ['field' => 'category', 'direction' => 'asc'] was making the test crash due to incomplete ORDER BY statement