### PR TITLE
Add new model definition for flagging scripts as modules (#8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.6.1 (draft)
+
+* Add support for marking scripts as JavaScript modules
+
 ## 3.6.0
 
 * Remove model based roles and permissions in preparations for a more streamlined RBAC

--- a/src/Mvc/Controller/KytePageController.php
+++ b/src/Mvc/Controller/KytePageController.php
@@ -266,7 +266,7 @@ class KytePageController extends ModelController
         foreach($libraries->objects as $library) {
             switch ($library->script_type) {
                 case 'js':
-                    $code .= '<script src="'.$library->link.'"></script>';
+                    $code .= '<script src="'.$library->link.'"'.($library->is_js_library == 1 ? ' type="module"' : '').'></script>';
                     break;
                 case 'css':
                     $code .= '<link rel="stylesheet" href="'.$library->link.'">';
@@ -388,7 +388,7 @@ class KytePageController extends ModelController
             if ($script->retrieve('id', $include->script, [['field' => 'state', 'value' => 1]])) {
                 switch ($script->script_type) {
                     case 'js':
-                        $code .= '<script src="/'.$script->s3key.'"></script>';
+                        $code .= '<script src="/'.$script->s3key.'"'.($library->is_js_library == 1 ? ' type="module"' : '').'></script>';
                         break;
                     case 'css':
                         $code .= '<link rel="stylesheet" href="/'.$script->s3key.'">';

--- a/src/Mvc/Model/KyteLibrary.php
+++ b/src/Mvc/Model/KyteLibrary.php
@@ -31,6 +31,15 @@ $KyteLibrary = [
 			'date'		=> false,
 		],
 
+		'is_js_module' => [
+			'type'		=> 'i',
+			'required'	=> false,
+			'size'		=> 1,
+			'unsigned'	=> true,
+			'default'	=> 0,
+			'date'		=> false,
+		],
+
 		'site'	=> [
 			'type'		=> 'i',
 			'required'	=> false,

--- a/src/Mvc/Model/KyteScript.php
+++ b/src/Mvc/Model/KyteScript.php
@@ -31,6 +31,15 @@ $KyteScript = [
 			'date'		=> false,
 		],
 
+		'is_js_module' => [
+			'type'		=> 'i',
+			'required'	=> false,
+			'size'		=> 1,
+			'unsigned'	=> true,
+			'default'	=> 0,
+			'date'		=> false,
+		],
+
 		'content'		=> [
 			'type'		=> 't',
 			'required'	=> false,


### PR DESCRIPTION
### Changes Proposed in This PR
Create a new attribute `is_js_module` for `KyteScript` and `KyteLibrary` models to store a boolean flag for marking a script as a module. Update the page controller to include the `type="module'` attribute for the `script` tag if the `is_js_module` is set.

### Acceptance Criteria Scenarios
When `is_js_module` is set to `1`, the page controller should correctly include the `type="module"` attribute in the `script` tag of the script in question.

### Linked Issues
Issue #8 

### Implementation Details
n/a

### Dependencies
None

### Testing Strategy
Confirm that scripts marked as modules have the `type="module"` attribute configured in the page that is generated.

### Screenshots/Video
None

### Checklist Before Requesting Review
- [x] Changes are complete and tested.
- [x] Pull request targets the correct branch.
- [x] Code is consistent with the existing codebase.
- [x] Linter/static analysis passes.
- [x] Existing tests pass.
- [x] Documentation and changelog are updated.

### Instructions for Reviewers
- Provide any specific instructions or areas of focus for the reviewers.
- Mention if there are any particular files or modules that require more attention.

### Follow-Up Tasks (If Applicable)
- List any follow-up tasks or next steps that should be taken after the pull request is merged.

### Additional Notes
- Include any other information that would be useful for the reviewers or maintainers.
