### PR TITLE
Fix to remove calls to deprecated Permission model (#17)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Add support for marking scripts as JavaScript modules
 * Add support for assigning element ID and/or class
 * Add support for default site langauge, and page specific languages
+* Bug fix to remove calls to deprecated Permission model
 
 ## 3.6.0
 

--- a/src/Mvc/Controller/DataModelController.php
+++ b/src/Mvc/Controller/DataModelController.php
@@ -136,13 +136,6 @@ class DataModelController extends ModelController
                         throw new \Exception("New model name is already in use.");
                     }
 
-                    // update permissions
-                    $perms = new \Kyte\Core\Model(Permission);
-                    $perms->retrieve("model", $o->name);
-                    foreach($perms->objects as $perm) {
-                        $perm->save([ "model" => $r['name'] ]);
-                    }
-
                     // switch dbs
                     $app = new \Kyte\Core\ModelObject(Application);
                     if (!$app->retrieve('id', $o->application)) {
@@ -176,13 +169,6 @@ class DataModelController extends ModelController
                 $attrs->retrieve("dataModel", $o->id);
                 foreach($attrs->objects as $attr) {
                     $attr->delete();
-                }
-
-                // delete perms
-                $perms = new \Kyte\Core\Model(Permission);
-                $perms->retrieve("model", $o->name);
-                foreach($perms->objects as $perm) {
-                    $perm->delete();
                 }
 
                 // delete controllers and remove function association

--- a/src/Mvc/Controller/DomainController.php
+++ b/src/Mvc/Controller/DomainController.php
@@ -72,10 +72,6 @@ class DomainController extends ModelController
             if (!in_array('update', $this->allowableActions)) {
                 return;
             }
-    
-            if (!$this->checkPermissions('update')) {
-                throw new \Exception('Permission Denied');
-            }
 
             if ($field === null || $value === null) throw new \Exception("Field and Values params not set");
 

--- a/src/Mvc/Controller/NavItemsController.php
+++ b/src/Mvc/Controller/NavItemsController.php
@@ -38,10 +38,6 @@ class NavItemsController extends ModelController
             if (!in_array('update', $this->allowableActions)) {
                 return;
             }
-    
-            if (!$this->checkPermissions('update')) {
-                throw new \Exception('Permission Denied');
-            }
 
             $conditions = null;
             if ($this->model !== null) {


### PR DESCRIPTION
### Changes Proposed in This PR
Remove calls and references to deprecated Permissions model

### Acceptance Criteria Scenarios
Removal of calls and references to deprecated Permissions model does not affect functionality or restores functionality.

### Linked Issues
Issue #17

### Implementation Details
n/a

### Dependencies
n/a

### Testing Strategy
Removal of calls and references to deprecated Permissions model does not affect functionality or restores functionality.

### Screenshots/Video
n/a

### Checklist Before Requesting Review
- [ ] Changes are complete and tested.
- [ ] Pull request targets the correct branch.
- [ ] Code is consistent with the existing codebase.
- [ ] Linter/static analysis passes.
- [ ] Existing tests pass.
- [ ] Documentation and changelog are updated.

### Instructions for Reviewers
n/a

### Follow-Up Tasks (If Applicable)
n/a

### Additional Notes
n/a
