### PR TITLE
Fix issue with wrong object being evaluated (#22)

### DIFF
--- a/src/Mvc/Controller/KytePageController.php
+++ b/src/Mvc/Controller/KytePageController.php
@@ -396,7 +396,7 @@ class KytePageController extends ModelController
             if ($script->retrieve('id', $include->script, [['field' => 'state', 'value' => 1]])) {
                 switch ($script->script_type) {
                     case 'js':
-                        $code .= '<script src="/'.$script->s3key.'"'.($library->is_js_library == 1 ? ' type="module"' : '').'></script>';
+                        $code .= '<script src="/'.$script->s3key.'"'.($script->is_js_library == 1 ? ' type="module"' : '').'></script>';
                         break;
                     case 'css':
                         $code .= '<link rel="stylesheet" href="/'.$script->s3key.'">';


### PR DESCRIPTION
### Changes Proposed in This PR
Fix issue where the `type="module"` attribute was not being added to the script tag of modules

### Acceptance Criteria Scenarios
Ensure that  `type="module"` attribute was being added to the script tag of JavaScript modules

### Linked Issues
Issue #22

### Implementation Details
Problem was `library` object was being evaluated when `script` object should have been.

### Dependencies
n/a

### Testing Strategy
Ensure that  `type="module"` attribute was being added to the script tag of JavaScript modules

### Screenshots/Video


### Checklist Before Requesting Review
- [ ] Changes are complete and tested.
- [ ] Pull request targets the correct branch.
- [ ] Code is consistent with the existing codebase.
- [ ] Linter/static analysis passes.
- [ ] Existing tests pass.
- [ ] Documentation and changelog are updated.
