### PR TITLE
Issue where is_js_library member variable was being evaluated when it…

### DIFF
--- a/src/Mvc/Controller/KytePageController.php
+++ b/src/Mvc/Controller/KytePageController.php
@@ -274,7 +274,7 @@ class KytePageController extends ModelController
         foreach($libraries->objects as $library) {
             switch ($library->script_type) {
                 case 'js':
-                    $code .= '<script src="'.$library->link.'"'.($library->is_js_library == 1 ? ' type="module"' : '').'></script>';
+                    $code .= '<script src="'.$library->link.'"'.($library->is_js_module == 1 ? ' type="module"' : '').'></script>';
                     break;
                 case 'css':
                     $code .= '<link rel="stylesheet" href="'.$library->link.'">';
@@ -396,7 +396,7 @@ class KytePageController extends ModelController
             if ($script->retrieve('id', $include->script, [['field' => 'state', 'value' => 1]])) {
                 switch ($script->script_type) {
                     case 'js':
-                        $code .= '<script src="/'.$script->s3key.'"'.($script->is_js_library == 1 ? ' type="module"' : '').'></script>';
+                        $code .= '<script src="/'.$script->s3key.'"'.($script->is_js_module == 1 ? ' type="module"' : '').'></script>';
                         break;
                     case 'css':
                         $code .= '<link rel="stylesheet" href="/'.$script->s3key.'">';


### PR DESCRIPTION
… should be is_js_module (#22)

### Changes Proposed in This PR
Revisit of #22
Problem was with a wrong member variable being evaluated

### Linked Issues
Issue #22

### Implementation Details
Fixed the member variable being evaluated. Problem was `is_js_library` being evaluated but this property doesn't exist.
Correct property is `is_js_module`

### Dependencies
n/a

### Screenshots/Video
- Include screenshots or video captures of new or updated UI/UX elements, if applicable.

### Checklist Before Requesting Review
- [x] Changes are complete and tested.
- [x] Pull request targets the correct branch.
- [x] Code is consistent with the existing codebase.
- [x] Linter/static analysis passes.
- [x] Existing tests pass.
- [x] Documentation and changelog are updated.
