### PR TITLE
field name parsed from URL should be URL decoded #29

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Add support for default site langauge, and page specific languages
 * Bug fix to remove calls to deprecated Permission model
 * Add support for additional MySQL types
+* Add URL decode for field name when parsing URL paths
 
 ## 3.6.0
 

--- a/src/Core/Api.php
+++ b/src/Core/Api.php
@@ -735,7 +735,7 @@ class Api
 
 		if (count($elements) >= 1) {
 			$this->model = $elements[0];
-			$this->field = isset($elements[1]) ? $elements[1] : null;
+			$this->field = isset($elements[1]) ? urldecode($elements[1]) : null;
 			$this->value = isset($elements[2]) ? urldecode($elements[2]) : null;
 
 			$this->response['model'] = $this->model;


### PR DESCRIPTION
### Changes Proposed in This PR
Field name should be url decoded when parsing the URL path, similar to how the value is url decoded.

### Linked Issues
Issue #29
Issue keyqcloud/kyte-api-js#4

### Implementation Details
Added `urldecode` for `$element[1]` which contains the field name parsed from the URL paths.

### Dependencies
n/a

### Testing Strategy
Confirm that the field name is correctly decoded.

### Checklist Before Requesting Review
- [x] Changes are complete and tested.
- [x] Pull request targets the correct branch.
- [x] Code is consistent with the existing codebase.
- [x] Linter/static analysis passes.
- [x] Existing tests pass.
- [x] Documentation and changelog are updated.