### PR TITLE
Fix issue where controller was not being deleted (#34)

### DIFF
--- a/src/Mvc/Controller/FunctionController.php
+++ b/src/Mvc/Controller/FunctionController.php
@@ -113,22 +113,25 @@ class FunctionController extends ModelController
                 $r['code'] = bzdecompress($r['code']);
                 break;
             case 'update':
+                $ctrl = new \Kyte\Core\ModelObject(constant("Controller"));
+                if (!$ctrl->retrieve("id", $o->controller)) {
+                    throw new \Exception("Unable to find specified controller.");
+                }
+
+                // update code base and save to file
+                ControllerController::generateCodeBase($ctrl);
+
+                $r['code'] = bzdecompress($r['code']);
+                break;
             case 'delete':                
                 $ctrl = new \Kyte\Core\ModelObject(constant("Controller"));
                 if (!$ctrl->retrieve("id", $o->controller)) {
                     throw new \Exception("Unable to find specified controller.");
                 }
 
-                $app = new \Kyte\Core\ModelObject(Application);
-                if (!$app->retrieve('id', $ctrl->application)) {
-                    throw new \Exception("CRITICAL ERROR: Unable to find application.");
-                }
-
                 // update code base and save to file
                 ControllerController::generateCodeBase($ctrl);
-
-                $r['code'] = '';
-            
+                break;            
             default:
                 break;
         }


### PR DESCRIPTION
### Changes Proposed in This PR
This PR fixes an issue where a function for a controller couldn't be deleted. The issue was due to a response value being set for update which was also being executed for delete.