### PR TITLE
Add member methods for deleting or purging retrieved objects (#41)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 3.6.5
 
 * Refactor code and remove unreachable statements following a throw.
+* Add member methods for deleting or purging retrieved objects.
 
 ## 3.6.4
 

--- a/src/Core/Model.php
+++ b/src/Core/Model.php
@@ -473,4 +473,50 @@ class Model
 		}
 		return $this->objects[$this->count()];
 	}
+
+	/**
+	 * Marks a entries as deleted in the database.
+	 *
+	 * This method marks items as deleted in the object array
+	 * and clears the array.
+	 * Requires that a retrieve is performed prior to calling.
+	 *
+	 * @return boolean
+	 */
+	public function deleteObjects() {
+		try {
+			foreach ($this->objects as $key => $obj) {
+				$obj->delete();
+				unset($this->objects[$key]);
+			}
+        
+			return true;
+
+		} catch (\Exception $e) {
+			throw $e;
+		}
+	}
+
+	/**
+	 * Permanently deletes database entries.
+	 *
+	 * This method purges items in the object array to
+	 * permanently delete items from database, and clears the array.
+	 * Requires that a retrieve is performed prior to calling.
+	 *
+	 * @return boolean
+	 */
+	public function purgeObjects() {
+		try {
+			foreach ($this->objects as $key => $obj) {
+				$obj->purge();
+				unset($this->objects[$key]);
+			}
+        
+			return true;
+
+		} catch (\Exception $e) {
+			throw $e;
+		}
+	}
 }


### PR DESCRIPTION
### Changes Proposed in This PR
This PR adds:
- `deleteObjects()`
- `purgeObjects()`

Which will delete or purge objects that have been retrieved. If no objects have been retrieved, the method will simply return. The method will also throw an exception if it fails to delete or purge an object.
