### PR TITLE
Add boolean to `KytePageData` to mark JS as module (#33)

### DIFF
--- a/src/Mvc/Model/KytePageData.php
+++ b/src/Mvc/Model/KytePageData.php
@@ -35,6 +35,15 @@ $KytePageData = [
 			'date'		=> false,
 		],
 
+		'is_js_module' => [
+			'type'		=> 'i',
+			'required'	=> false,
+			'size'		=> 1,
+			'unsigned'	=> true,
+			'default'	=> 0,
+			'date'		=> false,
+		],
+
 		'stylesheet'	=> [
 			'type'		=> 'lb',
 			'required'	=> false,


### PR DESCRIPTION
### Changes Proposed in This PR
This PR introduces the ability to mark JavaScript for a page as a module. This is useful when importing JS modules inside the page.