### PR TITLE
Ability to search foreign table attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.7.2
+
+* Enable foreign table attribute searches.
+
 ## 3.7.1
 
 * Improve DB fallback if SSL is not available

--- a/src/Core/Model.php
+++ b/src/Core/Model.php
@@ -103,12 +103,12 @@ class Model
 					$i = 1;
 					
 					foreach($search_fields as $sf) {
-						if (!array_key_exists($sf, $this->kyte_model['struct'])) {
-							$i++;
-							continue;
-						}
 						$f = explode(".", $sf);
 						if (count($f) == 1) {
+							if (!array_key_exists($sf, $this->kyte_model['struct'])) {
+								$i++;
+								continue;
+							}
 							if ($i < $c) {
 								$page_sql .= " `$main_tbl`.`$sf` LIKE '%{$escaped_value}%' OR";
 								$i++;
@@ -116,6 +116,10 @@ class Model
 								$page_sql .= " `$main_tbl`.`$sf` LIKE '%{$escaped_value}%' ";
 							}
 						} else if (count($f) == 2) {
+							if (!array_key_exists($f[0], $this->kyte_model['struct'])) {
+								$i++;
+								continue;
+							}
 							// initialize alias name as null
 							$tbl_alias = null;
 

--- a/src/Core/Version.php
+++ b/src/Core/Version.php
@@ -5,7 +5,7 @@ class Version
 {
     const MAJOR=3;
     const MINOR=7;
-    const PATCH=1;
+    const PATCH=2;
 
     public static function get()
     {


### PR DESCRIPTION
### Changes Proposed in This PR
Updated model code to enable searching of foreign tables linked to a model.

### Acceptance Criteria Scenarios
Searching attributes in foreign table correctly resolves.

### Linked Issues
Issue #62 

### Implementation Details
Correctly explode and verify foreign table attributes, which use dot notation (i.e. `fk_table.attribute`). Add join and correct table query to sql statement.

### Dependencies
None.

### Testing Strategy
Tested searches using KyteTable that rendered foreign table attributes.
Confirmed that foreign table attributes were correctly searched and results displayed data that matched the search query.
