### PR TITLE
[Missing] Added Role.php in Model directory

### DIFF
--- a/src/Mvc/Model/Role.php
+++ b/src/Mvc/Model/Role.php
@@ -1,0 +1,70 @@
+<?php
+
+$Role = [
+	'name' => 'Role',
+	'struct' => [
+		'name'		=> [
+			'type'		=> 's',
+			'required'	=> false,
+			'size'		=> 255,
+			'date'		=> false,
+		],
+
+		// framework attributes
+
+		'kyte_account'	=> [
+			'type'		=> 'i',
+			'required'	=> true,
+			'size'		=> 11,
+			'unsigned'	=> true,
+			'date'		=> false,
+		],
+
+		// audit attributes
+
+		'created_by'		=> [
+			'type'		=> 'i',
+			'required'	=> false,
+			'date'		=> false,
+		],
+
+		'date_created'		=> [
+			'type'		=> 'i',
+			'required'	=> false,
+			'date'		=> true,
+		],
+
+		'modified_by'		=> [
+			'type'		=> 'i',
+			'required'	=> false,
+			'date'		=> false,
+		],
+
+		'date_modified'		=> [
+			'type'		=> 'i',
+			'required'	=> false,
+			'date'		=> true,
+		],
+
+		'deleted_by'		=> [
+			'type'		=> 'i',
+			'required'	=> false,
+			'date'		=> false,
+		],
+
+		'date_deleted'		=> [
+			'type'		=> 'i',
+			'required'	=> false,
+			'date'		=> true,
+		],
+
+		'deleted'	=> [
+			'type'		=> 'i',
+			'required'	=> false,
+			'size'		=> 1,
+			'unsigned'	=> true,
+			'default'	=> 0,
+			'date'		=> false,
+		],
+	],
+];


### PR DESCRIPTION
### Changes Proposed in This PR
- There was no Role.php file in Model directory.
- Due to which the init account command was failing as it was looking for Role table which was missing during init db command.

### Acceptance Criteria Scenarios
- Make sure to again execute below command
```
php gust.php init db
```
- This will give you now 1 more table called Role
