### PR TITLE
[Missing] Added Permission.php in Model directory

### DIFF
--- a/src/Mvc/Model/Permission.php
+++ b/src/Mvc/Model/Permission.php
@@ -1,0 +1,82 @@
+<?php
+
+$Permission = [
+    'name' => 'Permission',
+    'struct' => [
+        'role' => [
+            'type'      => 'i',      // integer type
+            'required'  => true,
+            'size'      => 11,
+            'unsigned'  => true,
+            'date'      => false,
+        ],
+
+        'model' => [
+            'type'      => 's',      // string type (for the model name)
+            'required'  => true,
+            'size'      => 255,
+            'date'      => false,
+        ],
+
+        'action' => [
+            'type'      => 's',      // string type (for action like 'new', 'update', etc.)
+            'required'  => true,
+            'size'      => 255,
+            'date'      => false,
+        ],
+
+        'kyte_account' => [
+            'type'      => 'i',      // integer type (to link the permission to a kyte account)
+            'required'  => true,
+            'size'      => 11,
+            'unsigned'  => true,
+            'date'      => false,
+        ],
+
+        // Audit fields (standard for most tables)
+        'created_by' => [
+            'type'      => 'i',      // integer type
+            'required'  => false,
+            'date'      => false,
+        ],
+
+        'date_created' => [
+            'type'      => 'i',      // integer type (for timestamp)
+            'required'  => false,
+            'date'      => true,     // date field
+        ],
+
+        'modified_by' => [
+            'type'      => 'i',      // integer type
+            'required'  => false,
+            'date'      => false,
+        ],
+
+        'date_modified' => [
+            'type'      => 'i',      // integer type (for timestamp)
+            'required'  => false,
+            'date'      => true,     // date field
+        ],
+
+        'deleted_by' => [
+            'type'      => 'i',      // integer type
+            'required'  => false,
+            'date'      => false,
+        ],
+
+        'date_deleted' => [
+            'type'      => 'i',      // integer type (for timestamp)
+            'required'  => false,
+            'date'      => true,     // date field
+        ],
+
+        'deleted' => [
+            'type'      => 'i',      // integer type (0 or 1 for soft delete)
+            'required'  => false,
+            'size'      => 1,
+            'unsigned'  => true,
+            'default'   => 0,
+            'date'      => false,
+        ],
+    ],
+];


### PR DESCRIPTION
### Changes Proposed in This PR
- There was no Permission.php file in Model directory.
- Due to which the init account command was failing as it was looking for Permission table which was missing during init db command.

### Acceptance Criteria Scenarios
- Make sure to again execute below command
```
php gust.php init db
```
- This will give you now 1 more table called Permission
