### PR TITLE
Issue 72 - resolve issue with model definition not updating after adding, updating, or deleting a column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.7.6
+
+* Fix issue where model definition did not update correctly after creating, updating, or deleting a new column.
+
 ## 3.7.5
 
 * Add support for global includes for custom scripts. Requires a table change in the database (see below)

--- a/src/Core/Version.php
+++ b/src/Core/Version.php
@@ -5,7 +5,7 @@ class Version
 {
     const MAJOR=3;
     const MINOR=7;
-    const PATCH=5;
+    const PATCH=6;
 
     public static function get()
     {


### PR DESCRIPTION
Resolves an issue with model definition not updating correctly after adding, updating, deleting a column.
Issue was that the model definition update method was being called before the changes were being reflected in the DB. Updated controller to call the model definition update inside `hook_response_data` which gets triggered after SQL transaction completes.