### PR TITLE
Phase 1: auth middleware strategy-dispatcher refactor

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -5,6 +5,7 @@
       <file>tests/ApiTest.php</file>
       <file>tests/DatabaseTest.php</file>
       <file>tests/FunctionTest.php</file>
+      <file>tests/HmacSessionStrategyTest.php</file>
       <file>tests/ModelTest.php</file>
       <file>tests/SignatureTest.php</file>
     </testsuite>

--- a/src/Core/Api.php
+++ b/src/Core/Api.php
@@ -174,7 +174,16 @@ class Api
 		'CHECK_SYNTAX_ON_IMPORT' => false,
 		'STRICT_TYPING' => true,
 		'KYTE_USE_SNS' => false,
+		'AUTH_STRATEGY_DISPATCHER' => 'off',
 	];
+
+	/**
+	 * Auth strategy selected for the current request (set by validateRequest
+	 * when AUTH_STRATEGY_DISPATCHER != 'off'). Null on the legacy path.
+	 *
+	 * @var \Kyte\Core\Auth\AuthStrategy|null
+	 */
+	public $authStrategy = null;
 
 	/**
 	 * Model definition cache
@@ -938,16 +947,29 @@ class Api
 			error_log(print_r($this->data, true));
 		}
 
-		if (IS_PRIVATE) {
-			$this->signature = isset($_SERVER['HTTP_X_KYTE_SIGNATURE']) ? $_SERVER['HTTP_X_KYTE_SIGNATURE'] : null;
-			if (!$this->signature) {
+		if (AUTH_STRATEGY_DISPATCHER === 'on') {
+			// New strategy-dispatcher path. Functionally equivalent to the
+			// legacy branch below when HmacSessionStrategy matches.
+			$this->authStrategy = \Kyte\Core\Auth\AuthDispatcher::buildDefault()->select();
+			if ($this->authStrategy === null) {
 				return false;
 			}
-		}
+			$this->authStrategy->preAuth($this);
+			if (!$this->account) {
+				return false;
+			}
+		} else {
+			if (IS_PRIVATE) {
+				$this->signature = isset($_SERVER['HTTP_X_KYTE_SIGNATURE']) ? $_SERVER['HTTP_X_KYTE_SIGNATURE'] : null;
+				if (!$this->signature) {
+					return false;
+				}
+			}
 
-		$this->parseIdentityString(isset($_SERVER['HTTP_X_KYTE_IDENTITY']) ? $_SERVER['HTTP_X_KYTE_IDENTITY'] : null);
-		if (!$this->account) {
-			return false;
+			$this->parseIdentityString(isset($_SERVER['HTTP_X_KYTE_IDENTITY']) ? $_SERVER['HTTP_X_KYTE_IDENTITY'] : null);
+			if (!$this->account) {
+				return false;
+			}
 		}
 
 		// set page size
@@ -1008,7 +1030,9 @@ class Api
 
 			// default is always public.
 			// this can be bypassed for public APIs but is highly discouraged
-			if (IS_PRIVATE) {
+			if (AUTH_STRATEGY_DISPATCHER === 'on') {
+				$this->authStrategy->verify($this);
+			} elseif (IS_PRIVATE) {
 				// VERIFY SIGNATURE
 				$this->verifySignature();
 			}

--- a/src/Core/Api.php
+++ b/src/Core/Api.php
@@ -958,6 +958,9 @@ class Api
 			// New strategy-dispatcher path. Functionally equivalent to the
 			// legacy branch below when HmacSessionStrategy matches.
 			$this->authStrategy = \Kyte\Core\Auth\AuthDispatcher::buildDefault()->select();
+			if (VERBOSE_LOG > 0) {
+				error_log('auth: strategy_selected=' . ($this->authStrategy ? $this->authStrategy->name() : 'null'));
+			}
 			if ($this->authStrategy === null) {
 				return false;
 			}

--- a/src/Core/Api.php
+++ b/src/Core/Api.php
@@ -20,8 +20,9 @@ class Api
 
 	/**
      * @var \Kyte\Core\ModelObject The KyteAPIKey model object.
+     * Public to allow AuthStrategy implementations to populate during auth.
      */
-    private $key = null;
+    public $key = null;
     
     /**
      * * @var \Kyte\Core\ModelObject The KyteAccount model object.
@@ -52,15 +53,17 @@ class Api
      * The API signature.
      *
      * @var string|null
+     * Public to allow AuthStrategy implementations to populate during auth.
      */
-    private $signature = null;
-    
+    public $signature = null;
+
     /**
      * The UTC date.
      *
      * @var mixed|null
+     * Public to allow AuthStrategy implementations to populate during auth.
      */
-    private $utcDate = null;
+    public $utcDate = null;
     
     /**
      * The HTTP request model.

--- a/src/Core/Api.php
+++ b/src/Core/Api.php
@@ -947,6 +947,13 @@ class Api
 			error_log(print_r($this->data, true));
 		}
 
+		// Shadow mode snapshots the pre-auth response so the new strategy
+		// can be re-run from the same starting state after legacy completes.
+		$shadowEntryResponse = null;
+		if (AUTH_STRATEGY_DISPATCHER === 'shadow') {
+			$shadowEntryResponse = $this->response;
+		}
+
 		if (AUTH_STRATEGY_DISPATCHER === 'on') {
 			// New strategy-dispatcher path. Functionally equivalent to the
 			// legacy branch below when HmacSessionStrategy matches.
@@ -1035,6 +1042,12 @@ class Api
 			} elseif (IS_PRIVATE) {
 				// VERIFY SIGNATURE
 				$this->verifySignature();
+			}
+
+			// Shadow: legacy auth is fully applied at this point. Re-run the
+			// new dispatcher against a reset state and log any divergence.
+			if (AUTH_STRATEGY_DISPATCHER === 'shadow') {
+				\Kyte\Core\Auth\AuthShadowHarness::runAndCompare($this, $shadowEntryResponse);
 			}
 
 			return true;

--- a/src/Core/Auth/AuthDispatcher.php
+++ b/src/Core/Auth/AuthDispatcher.php
@@ -1,0 +1,54 @@
+<?php
+namespace Kyte\Core\Auth;
+
+use Kyte\Core\Api;
+
+/**
+ * Selects an auth strategy for the current request by consulting each
+ * registered strategy's matches() method in order. First match wins;
+ * no further strategies are consulted.
+ *
+ * Returns the selected strategy (or null if none claimed the request).
+ * Does not invoke preAuth/verify — the caller runs those at the correct
+ * points in the request lifecycle to preserve Api::validateRequest() ordering.
+ *
+ * See docs/design/kyte-mcp-and-auth-migration.md section 3.5.
+ */
+class AuthDispatcher
+{
+    /** @var AuthStrategy[] */
+    private $strategies;
+
+    /**
+     * @param AuthStrategy[] $strategies Ordered list. First match wins.
+     */
+    public function __construct(array $strategies)
+    {
+        $this->strategies = $strategies;
+    }
+
+    /**
+     * Returns the first strategy whose matches() returns true, or null.
+     */
+    public function select(): ?AuthStrategy
+    {
+        foreach ($this->strategies as $strategy) {
+            if ($strategy->matches()) {
+                return $strategy;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Convenience constructor wiring the default strategy stack for the
+     * current migration state. Phase 1: Hmac only. Phase 2 adds McpToken.
+     * Phase 3 adds JwtSession.
+     */
+    public static function buildDefault(): self
+    {
+        return new self([
+            new HmacSessionStrategy(),
+        ]);
+    }
+}

--- a/src/Core/Auth/AuthShadowHarness.php
+++ b/src/Core/Auth/AuthShadowHarness.php
@@ -1,0 +1,140 @@
+<?php
+namespace Kyte\Core\Auth;
+
+use Kyte\Core\Api;
+use Kyte\Core\ModelObject;
+
+/**
+ * Live shadow-mode harness: re-runs auth via the new AuthDispatcher
+ * against a controlled-reset Api state, compares the result to the
+ * legacy path's outcome, and logs any discrepancy.
+ *
+ * Enabled by setting AUTH_STRATEGY_DISPATCHER=shadow. Dev-only.
+ *
+ * Runs AFTER the legacy path has completed. The legacy result is
+ * restored before we return, so the response served to the client is
+ * always the legacy one. Shadow never affects the served response.
+ *
+ * Known side effects during shadow:
+ * - SessionManager::validate() runs twice per request (legacy, then new).
+ *   Each call may update a session's last-activity timestamp. Acceptable
+ *   during the Phase 1 soak on dev; not for production customers.
+ * - DB reads for account + api key occur twice per request.
+ */
+class AuthShadowHarness
+{
+    /**
+     * Compare the new dispatcher's auth result against the legacy result
+     * already applied to $api. Restores legacy state on exit.
+     *
+     * @param array $entryResponse $api->response as it was BEFORE legacy
+     *   auth ran — so the new path starts from the same initial state.
+     */
+    public static function runAndCompare(Api $api, array $entryResponse): void
+    {
+        $legacyFingerprint = self::fingerprint($api);
+
+        $legacyKey       = $api->key;
+        $legacyAccount   = $api->account;
+        $legacyUser      = $api->user;
+        $legacyResponse  = $api->response;
+        $legacySignature = $api->signature;
+        $legacyUtcDate   = $api->utcDate;
+
+        // Reset to the state Api::route() leaves us in just before validateRequest.
+        $api->key       = new ModelObject(KyteAPIKey);
+        $api->account   = new ModelObject(KyteAccount);
+        $api->user      = null;
+        $api->signature = null;
+        $api->utcDate   = null;
+        $api->response  = $entryResponse;
+
+        $strategy = null;
+        try {
+            $strategy = AuthDispatcher::buildDefault()->select();
+            if ($strategy !== null) {
+                $strategy->preAuth($api);
+                $strategy->verify($api);
+            }
+            $newFingerprint = self::fingerprint($api);
+
+            $diff = self::diff($legacyFingerprint, $newFingerprint);
+            if (!empty($diff)) {
+                self::logDiff($diff, $strategy);
+            }
+        } catch (\Throwable $e) {
+            self::logException($e, $strategy);
+        } finally {
+            $api->key       = $legacyKey;
+            $api->account   = $legacyAccount;
+            $api->user      = $legacyUser;
+            $api->response  = $legacyResponse;
+            $api->signature = $legacySignature;
+            $api->utcDate   = $legacyUtcDate;
+        }
+    }
+
+    private static function fingerprint(Api $api): array
+    {
+        return [
+            'key_id'     => ($api->key && isset($api->key->id)) ? $api->key->id : null,
+            'account_id' => ($api->account && isset($api->account->id)) ? $api->account->id : null,
+            'user_id'    => ($api->user && isset($api->user->id)) ? $api->user->id : null,
+            'session'    => $api->response['session'] ?? null,
+            'token'      => $api->response['token'] ?? null,
+            'uid'        => $api->response['uid'] ?? null,
+            'name'       => $api->response['name'] ?? null,
+            'email'      => $api->response['email'] ?? null,
+            'signature'  => $api->signature,
+            'utc_epoch'  => $api->utcDate ? $api->utcDate->format('U') : null,
+        ];
+    }
+
+    private static function diff(array $legacy, array $new): array
+    {
+        $out = [];
+        foreach ($legacy as $k => $v) {
+            $n = $new[$k] ?? null;
+            if ($v !== $n) {
+                $out[$k] = ['legacy' => $v, 'new' => $n];
+            }
+        }
+        return $out;
+    }
+
+    private static function logDiff(array $diff, ?AuthStrategy $strategy): void
+    {
+        try {
+            \Kyte\Core\ActivityLogger::getInstance()->log(
+                'AUTH_SHADOW_DIFF',
+                'AuthShadowHarness',
+                'strategy',
+                $strategy ? $strategy->name() : 'null',
+                null,
+                0,
+                'shadow',
+                json_encode($diff)
+            );
+        } catch (\Throwable $e) {
+            error_log('AuthShadowHarness: failed to log diff - ' . $e->getMessage());
+        }
+    }
+
+    private static function logException(\Throwable $e, ?AuthStrategy $strategy): void
+    {
+        try {
+            \Kyte\Core\ActivityLogger::getInstance()->log(
+                'AUTH_SHADOW_EXCEPTION',
+                'AuthShadowHarness',
+                'strategy',
+                $strategy ? $strategy->name() : 'null',
+                null,
+                0,
+                'shadow',
+                get_class($e) . ': ' . $e->getMessage()
+            );
+        } catch (\Throwable $inner) {
+            error_log('AuthShadowHarness: failed to log exception - ' . $inner->getMessage());
+        }
+    }
+}

--- a/src/Core/Auth/AuthStrategy.php
+++ b/src/Core/Auth/AuthStrategy.php
@@ -1,0 +1,46 @@
+<?php
+namespace Kyte\Core\Auth;
+
+use Kyte\Core\Api;
+
+/**
+ * Contract for request-authentication strategies.
+ *
+ * A strategy inspects the request (headers, config) to decide whether it
+ * claims responsibility, then performs its two-phase auth work against a
+ * supplied Api instance.
+ *
+ * Two-phase split preserves current Api::validateRequest() ordering:
+ *   1. preAuth()  — populate $api->key, $api->account, $api->user, $api->session,
+ *                   and the identity-related $api->response slots.
+ *   2. (caller performs URL parsing + response hydration)
+ *   3. verify()   — final signature/token check. May be a no-op.
+ *
+ * See docs/design/kyte-mcp-and-auth-migration.md section 3.5.
+ */
+interface AuthStrategy
+{
+    /**
+     * Does this strategy claim responsibility for the current request?
+     * Inspects headers and per-install config. Pure; no side effects.
+     */
+    public function matches(): bool;
+
+    /**
+     * Phase 1: identity parse + user/account/session lookup.
+     * Populates Api state. Throws SessionException / Exception on failure.
+     */
+    public function preAuth(Api $api): void;
+
+    /**
+     * Phase 2: final signature or token verification.
+     * Called after URL parsing + response hydration. May be a no-op
+     * (e.g. identity-only mode). Throws SessionException on failure.
+     */
+    public function verify(Api $api): void;
+
+    /**
+     * Short label for logging and telemetry (e.g. "hmac_session").
+     */
+    public function name(): string;
+}

--- a/src/Core/Auth/HmacSessionStrategy.php
+++ b/src/Core/Auth/HmacSessionStrategy.php
@@ -1,0 +1,153 @@
+<?php
+namespace Kyte\Core\Auth;
+
+use Kyte\Core\Api;
+use Kyte\Exception\SessionException;
+
+/**
+ * Wraps the legacy three-layer HMAC-SHA256 auth flow currently inlined
+ * in Api::parseIdentityString() and Api::verifySignature().
+ *
+ * Behavior must be bit-for-bit identical to those methods; Phase 0
+ * characterization tests in tests/SignatureTest.php are the contract.
+ *
+ * Flavors (both handled here):
+ *   - IS_PRIVATE=true  — signature + identity required
+ *   - IS_PRIVATE=false — identity-only (no signature verification)
+ */
+class HmacSessionStrategy implements AuthStrategy
+{
+    public function name(): string
+    {
+        return 'hmac_session';
+    }
+
+    /**
+     * Matches every request EXCEPT the IS_PRIVATE + missing-signature case,
+     * which is the /sign helper path and falls through to Api::generateSignature.
+     *
+     * A missing identity header is NOT handled here — it's left for preAuth()
+     * to throw "Invalid identity string" as the legacy code does. matches()
+     * only decides "do we attempt auth at all"; preAuth decides "does the
+     * request's auth payload make sense". This split mirrors
+     * Api::validateRequest's original return-false vs. throw branches exactly.
+     */
+    public function matches(): bool
+    {
+        if (IS_PRIVATE && empty($_SERVER['HTTP_X_KYTE_SIGNATURE'])) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Mirrors Api::parseIdentityString. Populates key, account, session,
+     * user, and the identity-related response slots.
+     */
+    public function preAuth(Api $api): void
+    {
+        if (IS_PRIVATE) {
+            $api->signature = $_SERVER['HTTP_X_KYTE_SIGNATURE'] ?? null;
+        }
+
+        $raw = $_SERVER['HTTP_X_KYTE_IDENTITY'] ?? null;
+        $identity = explode('%', base64_decode(urldecode($raw)));
+
+        if (count($identity) != 4) {
+            throw new SessionException("[ERROR] Invalid identity string: {$api->request}.");
+        }
+
+        $api->utcDate = new \DateTime($identity[2], new \DateTimeZone('UTC'));
+
+        if (time() > $api->utcDate->format('U') + SIGNATURE_TIMEOUT) {
+            throw new SessionException("API request has expired.");
+        }
+
+        if (!isset($identity[0])) {
+            throw new \Exception("API key is required.");
+        }
+
+        if (!$api->key->retrieve('public_key', $identity[0])) {
+            throw new \Exception("API key not found.");
+        }
+
+        if (!$api->account->retrieve('number', $identity[3])) {
+            throw new \Exception("[ERROR] Unable to find account for {$identity[3]}.");
+        }
+
+        $identity[1] = $identity[1] == 'undefined' ? "0" : $identity[1];
+        $api->response['session'] = $identity[1];
+
+        if ($identity[1] != "0") {
+            $session_ret = $api->session->validate($identity[1]);
+            $api->response['session'] = $session_ret['session']->sessionToken;
+            $api->response['token'] = $session_ret['session']->txToken;
+
+            $api->user = $session_ret['user'];
+            $api->response['uid'] = $api->user->id;
+            $api->response['name'] = $api->user->name;
+            $api->response['email'] = $api->user->email;
+
+            if ($api->appId === null && $api->user->kyte_account != $api->account->id) {
+                if (!$api->account->retrieve('id', $api->user->kyte_account)) {
+                    throw new \Exception("Unable to find account associated with the user");
+                }
+            }
+
+            $finalLanguage = APP_LANG;
+            if ($api->account && isset($api->account->default_language) && !empty($api->account->default_language)) {
+                $finalLanguage = $api->account->default_language;
+            }
+            if ($api->app && isset($api->app->language) && !empty($api->app->language)) {
+                $finalLanguage = $api->app->language;
+            }
+            if ($api->user && isset($api->user->language) && !empty($api->user->language)) {
+                $finalLanguage = $api->user->language;
+            }
+            \Kyte\Util\I18n::setLanguage($finalLanguage);
+        }
+    }
+
+    /**
+     * Mirrors Api::verifySignature. No-op in IS_PRIVATE=false mode.
+     */
+    public function verify(Api $api): void
+    {
+        if (!IS_PRIVATE) {
+            return;
+        }
+
+        $token = $api->response['token'];
+        $secretKey = $api->key->secret_key;
+        $identifier = $api->key->identifier;
+
+        $hash1 = hash_hmac('SHA256', $token, $secretKey, true);
+        $hash1str = hash_hmac('SHA256', $token, $secretKey, false);
+
+        if (VERBOSE_LOG > 0) {
+            error_log("hash1 " . hash_hmac('SHA256', $token, $secretKey));
+        }
+
+        $hash2 = hash_hmac('SHA256', $identifier, $hash1, true);
+        $hash2str = hash_hmac('SHA256', $identifier, $hash1, false);
+
+        if (VERBOSE_LOG > 0) {
+            error_log("hash2 " . hash_hmac('SHA256', $identifier, $hash1));
+        }
+
+        $calculated = hash_hmac('SHA256', $api->utcDate->format('U'), $hash2);
+
+        if (VERBOSE_LOG > 0) {
+            error_log("hash3 $calculated");
+            error_log("epoch " . $api->utcDate->format('U'));
+        }
+
+        if ($calculated != $api->signature) {
+            throw new SessionException(
+                "Calculated signature does not match provided signature.\n" .
+                "Calculated: $hash1str $hash2str $calculated\n" .
+                "Provided: " . $api->signature
+            );
+        }
+    }
+}

--- a/tests/HmacSessionStrategyTest.php
+++ b/tests/HmacSessionStrategyTest.php
@@ -1,0 +1,206 @@
+<?php
+namespace Kyte\Test;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Parallel characterization tests for Kyte\Core\Auth\HmacSessionStrategy.
+ *
+ * Mirrors the cases in SignatureTest.php that cover parseIdentityString and
+ * verifySignature, but exercises them via the new strategy surface instead
+ * of via reflection on Api's private methods. Together the two files form
+ * the Phase 1 contract: HmacSessionStrategy must behave identically to the
+ * legacy inline auth code, in every branch.
+ *
+ * See docs/design/kyte-mcp-and-auth-migration.md Phase 1.
+ */
+class HmacSessionStrategyTest extends TestCase
+{
+    private const FIXED_SECRET     = 'test-secret-key-12345';
+    private const FIXED_PUBLIC_KEY = 'test-public-key-strat';
+    private const FIXED_IDENTIFIER = 'test-identifier-strat';
+    private const FIXED_ACCOUNT    = 'test-account-strat';
+
+    /** @var \Kyte\Core\Api */
+    private $api;
+
+    /** @var \Kyte\Core\Auth\HmacSessionStrategy */
+    private $strategy;
+
+    protected function setUp(): void
+    {
+        \Kyte\Core\DBI::dbInit(KYTE_DB_USERNAME, KYTE_DB_PASSWORD, KYTE_DB_HOST, KYTE_DB_DATABASE, KYTE_DB_CHARSET, 'InnoDB');
+
+        $this->api = new \Kyte\Core\Api();
+        $this->strategy = new \Kyte\Core\Auth\HmacSessionStrategy();
+
+        \Kyte\Core\DBI::createTable(KyteAPIKey);
+        \Kyte\Core\DBI::createTable(KyteAccount);
+
+        \Kyte\Core\DBI::query("DELETE FROM `KyteAPIKey` WHERE public_key = '" . self::FIXED_PUBLIC_KEY . "'");
+        \Kyte\Core\DBI::query("DELETE FROM `KyteAccount` WHERE number = '" . self::FIXED_ACCOUNT . "'");
+
+        $account = new \Kyte\Core\ModelObject(KyteAccount);
+        $account->create([
+            'name'   => 'HmacStrategy Test Account',
+            'number' => self::FIXED_ACCOUNT,
+        ]);
+
+        $apiKey = new \Kyte\Core\ModelObject(KyteAPIKey);
+        $apiKey->create([
+            'identifier'   => self::FIXED_IDENTIFIER,
+            'public_key'   => self::FIXED_PUBLIC_KEY,
+            'secret_key'   => self::FIXED_SECRET,
+            'epoch'        => 0,
+            'kyte_account' => $account->id,
+        ]);
+
+        // Match the preconditions Api::route() establishes before validateRequest runs.
+        $this->api->key = new \Kyte\Core\ModelObject(KyteAPIKey);
+        $this->api->account = new \Kyte\Core\ModelObject(KyteAccount);
+        $this->api->response = ['session' => '0', 'token' => '0', 'uid' => '0'];
+
+        $_SERVER = [];
+    }
+
+    private function identityHeader(string $publicKey, string $session, int $epoch, string $account): string
+    {
+        $date = gmdate('D, d M Y H:i:s', $epoch) . ' GMT';
+        return urlencode(base64_encode($publicKey . '%' . $session . '%' . $date . '%' . $account));
+    }
+
+    private function signatureFor(string $token, string $secret, string $identifier, int $epoch): string
+    {
+        $h1 = hash_hmac('SHA256', $token, $secret, true);
+        $h2 = hash_hmac('SHA256', $identifier, $h1, true);
+        return hash_hmac('SHA256', (string)$epoch, $h2);
+    }
+
+    public function testMatchesReturnsTrueWithSignatureAndIdentityInPrivateMode(): void
+    {
+        $_SERVER['HTTP_X_KYTE_SIGNATURE'] = 'anything';
+        $_SERVER['HTTP_X_KYTE_IDENTITY']  = 'anything';
+        $this->assertTrue($this->strategy->matches());
+    }
+
+    public function testMatchesReturnsFalseWhenPrivateAndNoSignature(): void
+    {
+        $_SERVER['HTTP_X_KYTE_IDENTITY'] = 'anything';
+        // No HTTP_X_KYTE_SIGNATURE — this is the /sign helper path.
+        $this->assertFalse($this->strategy->matches());
+    }
+
+    public function testPreAuthAcceptsValidIdentityAndPopulatesState(): void
+    {
+        $now = time();
+        $_SERVER['HTTP_X_KYTE_SIGNATURE'] = 'placeholder';
+        $_SERVER['HTTP_X_KYTE_IDENTITY']  = $this->identityHeader(self::FIXED_PUBLIC_KEY, '0', $now, self::FIXED_ACCOUNT);
+
+        $this->strategy->preAuth($this->api);
+
+        $this->assertSame(self::FIXED_PUBLIC_KEY, $this->api->key->public_key);
+        $this->assertSame(self::FIXED_ACCOUNT, $this->api->account->number);
+        $this->assertSame('0', $this->api->response['session']);
+        $this->assertNull($this->api->user, 'Anonymous session should not populate user');
+    }
+
+    public function testPreAuthRejectsExpiredTimestamp(): void
+    {
+        $stale = time() - 7200;
+        $_SERVER['HTTP_X_KYTE_SIGNATURE'] = 'placeholder';
+        $_SERVER['HTTP_X_KYTE_IDENTITY']  = $this->identityHeader(self::FIXED_PUBLIC_KEY, '0', $stale, self::FIXED_ACCOUNT);
+
+        $this->expectException(\Kyte\Exception\SessionException::class);
+        $this->expectExceptionMessage('API request has expired');
+        $this->strategy->preAuth($this->api);
+    }
+
+    public function testPreAuthAcceptsTimestampAtBoundary(): void
+    {
+        $boundary = time() - SIGNATURE_TIMEOUT;
+        $_SERVER['HTTP_X_KYTE_SIGNATURE'] = 'placeholder';
+        $_SERVER['HTTP_X_KYTE_IDENTITY']  = $this->identityHeader(self::FIXED_PUBLIC_KEY, '0', $boundary, self::FIXED_ACCOUNT);
+
+        $this->strategy->preAuth($this->api);
+        $this->addToAssertionCount(1);
+    }
+
+    public function testPreAuthRejectsTimestampOneSecondPastBoundary(): void
+    {
+        $stale = time() - SIGNATURE_TIMEOUT - 1;
+        $_SERVER['HTTP_X_KYTE_SIGNATURE'] = 'placeholder';
+        $_SERVER['HTTP_X_KYTE_IDENTITY']  = $this->identityHeader(self::FIXED_PUBLIC_KEY, '0', $stale, self::FIXED_ACCOUNT);
+
+        $this->expectException(\Kyte\Exception\SessionException::class);
+        $this->expectExceptionMessage('API request has expired');
+        $this->strategy->preAuth($this->api);
+    }
+
+    public function testPreAuthRejectsMalformedIdentity(): void
+    {
+        $_SERVER['HTTP_X_KYTE_SIGNATURE'] = 'placeholder';
+        $_SERVER['HTTP_X_KYTE_IDENTITY']  = urlencode(base64_encode('only%three%parts'));
+
+        $this->expectException(\Kyte\Exception\SessionException::class);
+        $this->expectExceptionMessage('Invalid identity string');
+        $this->strategy->preAuth($this->api);
+    }
+
+    public function testPreAuthRejectsUnknownApiKey(): void
+    {
+        $now = time();
+        $_SERVER['HTTP_X_KYTE_SIGNATURE'] = 'placeholder';
+        $_SERVER['HTTP_X_KYTE_IDENTITY']  = $this->identityHeader('nonexistent-key', '0', $now, self::FIXED_ACCOUNT);
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('API key not found');
+        $this->strategy->preAuth($this->api);
+    }
+
+    public function testPreAuthRejectsUnknownAccount(): void
+    {
+        $now = time();
+        $_SERVER['HTTP_X_KYTE_SIGNATURE'] = 'placeholder';
+        $_SERVER['HTTP_X_KYTE_IDENTITY']  = $this->identityHeader(self::FIXED_PUBLIC_KEY, '0', $now, 'nonexistent-account');
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Unable to find account');
+        $this->strategy->preAuth($this->api);
+    }
+
+    public function testPreAuthTreatsUndefinedSessionAsZero(): void
+    {
+        $now = time();
+        $date = gmdate('D, d M Y H:i:s', $now) . ' GMT';
+        $_SERVER['HTTP_X_KYTE_SIGNATURE'] = 'placeholder';
+        $_SERVER['HTTP_X_KYTE_IDENTITY']  = urlencode(base64_encode(
+            self::FIXED_PUBLIC_KEY . '%undefined%' . $date . '%' . self::FIXED_ACCOUNT
+        ));
+
+        $this->strategy->preAuth($this->api);
+        $this->assertSame('0', $this->api->response['session']);
+    }
+
+    public function testVerifyAcceptsCorrectSignature(): void
+    {
+        $now = time();
+        $_SERVER['HTTP_X_KYTE_IDENTITY']  = $this->identityHeader(self::FIXED_PUBLIC_KEY, '0', $now, self::FIXED_ACCOUNT);
+        $_SERVER['HTTP_X_KYTE_SIGNATURE'] = $this->signatureFor('0', self::FIXED_SECRET, self::FIXED_IDENTIFIER, $now);
+
+        $this->strategy->preAuth($this->api);
+        $this->strategy->verify($this->api);
+        $this->addToAssertionCount(1);
+    }
+
+    public function testVerifyRejectsWrongSignature(): void
+    {
+        $now = time();
+        $_SERVER['HTTP_X_KYTE_IDENTITY']  = $this->identityHeader(self::FIXED_PUBLIC_KEY, '0', $now, self::FIXED_ACCOUNT);
+        $_SERVER['HTTP_X_KYTE_SIGNATURE'] = str_repeat('0', 64);
+
+        $this->strategy->preAuth($this->api);
+
+        $this->expectException(\Kyte\Exception\SessionException::class);
+        $this->strategy->verify($this->api);
+    }
+}


### PR DESCRIPTION
## Summary

Phase 1 of the Kyte MCP / auth migration. Refactors the inline HMAC auth code in `Api::validateRequest` into a strategy-pattern abstraction, without changing behavior for existing clients. Four commits:

1. **Introduce scaffolding as dead code.** `src/Core/Auth/AuthStrategy.php` (interface), `HmacSessionStrategy.php` (wraps the legacy three-layer HMAC-SHA256 flow line-for-line), `AuthDispatcher.php` (first-match-wins router). No wiring yet. Bumps `$key`, `$signature`, `$utcDate` from `private` to `public` on `Api` so strategies can populate.
2. **Wire the dispatcher behind a per-install flag.** `AUTH_STRATEGY_DISPATCHER` constant added to `$defaultEnvironmentConstants` with default `'off'`. When `'off'`, legacy inline auth runs — byte-identical behavior to v4.2.0. When `'on'`, `AuthDispatcher::buildDefault()` selects a strategy, `preAuth()` runs before URL parsing, `verify()` runs after response hydration — same two points where the legacy code called `parseIdentityString` and `verifySignature`, preserving response-body ordering on 403s.
3. **Live shadow-mode harness.** `AuthShadowHarness::runAndCompare()`. When `AUTH_STRATEGY_DISPATCHER='shadow'`, legacy auth runs normally and serves the response. After it completes, the harness resets `Api` state to pre-auth, re-runs the dispatcher, and compares fingerprints (`key_id`, `account_id`, `user_id`, `response[session/token/uid/name/email]`, `signature`, `utc_epoch`). Divergences log via `ActivityLogger` as `AUTH_SHADOW_DIFF`; new-path exceptions log as `AUTH_SHADOW_EXCEPTION`. Legacy state is restored in a `finally` block before the caller returns.
4. **Parallel characterization tests + strategy-selection log.** `tests/HmacSessionStrategyTest.php` with 12 tests exercising `matches / preAuth / verify` directly — same edge cases as Phase 0's `SignatureTest` (boundary, expired, malformed, unknown key/account, undefined-session quirk). A lightweight `VERBOSE_LOG`-gated `error_log` of the selected strategy name.

### Flag mechanism decision

Design doc O2 originally proposed `AppConfig` for this flag. Revised here to a per-install PHP constant because `AppConfig` is keyed by `kyte_account` (required), which the auth flow itself is responsible for resolving — chicken-and-egg. Per-install constants match the pattern of `IS_PRIVATE`, `SIGNATURE_TIMEOUT`, etc. Design doc O2 updated with the rationale.

### Known side effects of shadow mode

Documented in `AuthShadowHarness.php`:

- `SessionManager::validate()` runs twice per request during shadow (legacy, then new). Each call may update a session's `last_activity` timestamp. Acceptable for the dev-only soak; should not be enabled on customer installs.
- One extra DB read for `KyteAccount` + `KyteAPIKey` per request.

After the Phase 1 cutover on a given install, `shadow` mode is never used again there.

### Testing

- 30/30 unit tests green (18 Phase 0 + 12 new), 103 assertions, zero warnings / zero deprecations under PHPUnit 11 / PHP 8.2.
- CLI smoke test of flag=on with real DB fixtures: dispatcher selects `hmac_session`, preAuth loads account + key, verify accepts signature.
- CLI smoke test of flag=shadow with matching-state case (no diff logged) and forced-mismatch case (diff detected, log attempted, state cleanly restored).

### Explicitly deferred to Phase 2

- Structured `AUTH_STRATEGY_SELECTED` activity-log entries. With only one strategy today, per-request logging would be noise. When Phase 2 introduces `McpTokenStrategy`, the stub in `Api.php` can graduate.

## Post-merge plan

1. Tag `v4.3.0`.
2. Upgrade dev Kyte server to `v4.3.0`, set `AUTH_STRATEGY_DISPATCHER='shadow'` in its `config.php`.
3. Soak for 2–4 weeks. Verify `SELECT * FROM KyteActivityLog WHERE action LIKE 'AUTH_SHADOW_%'` returns zero rows (or only rows we can explain).
4. Flip to `AUTH_STRATEGY_DISPATCHER='on'`. Soak another week on dev.
5. Open `feature/phase-2-mcp-tokens` off the tagged commit.

## Test plan

- [x] 30/30 unit tests green locally under Docker (MariaDB 10.5.29, PHP 8.2)
- [ ] GitHub Actions green on push
- [ ] Dev server: install `v4.3.0`, flag=off → verify legacy path works (no-op upgrade)
- [ ] Dev server: flip flag=shadow → 2-4 week soak, zero unexplained `AUTH_SHADOW_*` rows
- [ ] Dev server: flip flag=on → 1 week soak, no auth regressions
- [ ] Dev server: flip flag=off → verify rollback still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)