### PR TITLE
Fix DBI::buildFieldDefinition for null defaults

### DIFF
--- a/src/Core/DBI.php
+++ b/src/Core/DBI.php
@@ -568,7 +568,11 @@ class DBI {
 		// Default value
 		if (array_key_exists('default', $attrs)) {
 			$field .= ' DEFAULT ';
-			$field .= (is_string($attrs['default']) ? "'" . $attrs['default'] . "'" : $attrs['default']);
+			if (is_null($attrs['default'])) {
+				$field .= 'NULL';
+			} else {
+				$field .= (is_string($attrs['default']) ? "'" . $attrs['default'] . "'" : $attrs['default']);
+			}
 		}
 
 		// Required/NOT NULL

--- a/tests/DatabaseTest.php
+++ b/tests/DatabaseTest.php
@@ -23,4 +23,61 @@ class DatabaseTest extends TestCase
         $password = null;
         $this->assertTrue(\Kyte\Core\DBI::createDatabase("TestDatabase2", "TestUser2", $password, true));
     }
+
+    /**
+     * Regression test: createTable must accept fields declared with
+     * 'default' => null and emit DEFAULT NULL in the generated SQL.
+     *
+     * Before this was fixed, buildFieldDefinition's default-value branch fell
+     * through to a fall-through concat that coerced null to '', producing
+     * broken SQL like `language varchar(5) DEFAULT  NOT NULL,`. The Application
+     * model's `language` field has 'default' => null, so any fresh createTable
+     * of it (e.g. during install) blew up. gust/lib/Database.php still has an
+     * identical copy of this bug and should be patched when gust is next
+     * touched (see design doc section 11, gust evaluation).
+     */
+    public function testCreateTableAcceptsNullDefault() {
+        // The preceding createDatabase tests leave the mysqli connection
+        // without an active database context. Re-select kytedev explicitly.
+        // dbInit won't help here because connect() early-returns once a
+        // connection object already exists.
+        \Kyte\Core\DBI::query('USE `' . KYTE_DB_DATABASE . '`');
+
+        $tblName = 'NullDefaultProbe_' . substr(bin2hex(random_bytes(4)), 0, 8);
+
+        $modelDef = [
+            'name' => $tblName,
+            'struct' => [
+                'id' => [
+                    'type'     => 'i',
+                    'required' => true,
+                    'pk'       => true,
+                    'size'     => 11,
+                    'date'     => false,
+                ],
+                'optional_label' => [
+                    'type'     => 's',
+                    'required' => false,
+                    'size'     => 64,
+                    'date'     => false,
+                    'default'  => null,
+                ],
+            ],
+        ];
+
+        try {
+            $this->assertTrue(\Kyte\Core\DBI::createTable($modelDef));
+
+            $rows = \Kyte\Core\DBI::query("SHOW CREATE TABLE `$tblName`");
+            $this->assertNotEmpty($rows);
+            $createSql = $rows[0]['Create Table'] ?? '';
+            $this->assertStringContainsStringIgnoringCase(
+                'DEFAULT NULL',
+                $createSql,
+                "Column with 'default' => null should surface as DEFAULT NULL in SHOW CREATE TABLE output."
+            );
+        } finally {
+            \Kyte\Core\DBI::query("DROP TABLE IF EXISTS `$tblName`");
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Four-line fix to `DBI::buildFieldDefinition` so a field declared with `'default' => null` emits valid `DEFAULT NULL` SQL instead of a dangling `DEFAULT ` that MariaDB rejects.
- Characterization test (`testCreateTableAcceptsNullDefault`) covering the regression.

## Why
`Application` model's `language` field carries `'default' => null`. Any fresh `DBI::createTable(Application)` has been blowing up since that field was added — existing customer installs are unaffected because the table already exists. The bug was uncovered while writing a Phase 2 MCP integration test that needed a fresh `Application` table.

`gust/lib/Database.php` contains an identical copy of this bug. Patching gust is out of scope for this PR (separate initiative per design doc §11); noted in the commit message for the next gust-refresh session.

## Test plan
- [x] `docker compose -f tests/docker-compose.test.yml run --rm php vendor/bin/phpunit --testsuite unit` green locally (31/31)
- [x] CI green on this PR
- [x] Visual spot-check that `DEFAULT NULL` appears in `SHOW CREATE TABLE` for a field with `'default' => null`