### PR TITLE
Read version from Composer runtime, not hardcoded constants

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,6 +8,7 @@
       <file>tests/HmacSessionStrategyTest.php</file>
       <file>tests/ModelTest.php</file>
       <file>tests/SignatureTest.php</file>
+      <file>tests/VersionTest.php</file>
     </testsuite>
     <testsuite name="aws">
       <file>tests/AwsAcmTest.php</file>

--- a/src/Core/Version.php
+++ b/src/Core/Version.php
@@ -1,14 +1,39 @@
 <?php
 namespace Kyte\Core;
 
+/**
+ * Reports the running kyte-php version.
+ *
+ * Reads Composer's runtime installed-package data via Composer\InstalledVersions
+ * (Composer 2.x API). Returns the pretty version string composer resolved:
+ *
+ *   - Tagged install:    "v4.3.2"
+ *   - Branch install:    "dev-master" / "dev-feature/phase-2-mcp-tokens"
+ *   - Dev tree (no composer registration): "unknown"
+ *
+ * Replaces the old hardcoded MAJOR/MINOR/PATCH constants, which went stale
+ * (v4.1.1 was reported on v4.3.x installs because nobody bumped the consts).
+ */
 class Version
 {
-    const MAJOR=4;
-    const MINOR=1;
-    const PATCH=1;
+    private const FALLBACK = 'unknown';
+    private const PACKAGE  = 'keyqcloud/kyte-php';
 
-    public static function get()
+    public static function get(): string
     {
-        return sprintf('v%s.%s.%s', self::MAJOR, self::MINOR, self::PATCH);
+        if (!class_exists(\Composer\InstalledVersions::class)) {
+            return self::FALLBACK;
+        }
+
+        try {
+            $version = \Composer\InstalledVersions::getPrettyVersion(self::PACKAGE);
+        } catch (\OutOfBoundsException $e) {
+            // Package not registered in Composer's runtime data — happens
+            // when running a dev tree that hasn't been composer-installed
+            // (e.g. directly from a git clone).
+            return self::FALLBACK;
+        }
+
+        return $version ?? self::FALLBACK;
     }
 }

--- a/tests/VersionTest.php
+++ b/tests/VersionTest.php
@@ -1,0 +1,38 @@
+<?php
+namespace Kyte\Test;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Characterization tests for Kyte\Core\Version::get().
+ *
+ * The previous implementation hardcoded MAJOR/MINOR/PATCH constants that
+ * were never bumped — every install reported v4.1.1 regardless of what
+ * composer actually pulled. v4.3.2 replaced that with a Composer\InstalledVersions
+ * lookup; these tests pin the new contract.
+ */
+class VersionTest extends TestCase
+{
+    public function testGetReturnsNonEmptyString(): void
+    {
+        $version = \Kyte\Core\Version::get();
+        $this->assertIsString($version);
+        $this->assertNotSame('', $version);
+    }
+
+    public function testGetReturnsComposerInstalledVersion(): void
+    {
+        // Composer's runtime data is always present in a composer-installed
+        // tree (which the test suite is). Confirm we surface its pretty
+        // version, not the FALLBACK.
+        $expected = \Composer\InstalledVersions::getPrettyVersion('keyqcloud/kyte-php');
+        $this->assertSame($expected, \Kyte\Core\Version::get());
+    }
+
+    public function testGetDoesNotReturnHardcodedLegacyString(): void
+    {
+        // Guard against a regression where someone reintroduces the
+        // pre-v4.3.2 hardcoded "v4.1.1" string.
+        $this->assertNotSame('v4.1.1', \Kyte\Core\Version::get());
+    }
+}


### PR DESCRIPTION
## Summary
- Replace hardcoded `MAJOR/MINOR/PATCH` constants in `src/Core/Version.php` with `\Composer\InstalledVersions::getPrettyVersion('keyqcloud/kyte-php')`.
- 3 new tests pin the new contract.

## Why
The old implementation required manual bumps on every release. Nobody did — every install reported `v4.1.1` regardless of what composer actually pulled. The MCP `serverInfo.version` handshake surfaced this on a v4.3.1 install during Phase 2 dev verification last session.

Composer 2.x's `InstalledVersions` API is the idiomatic answer: returns `"v4.3.2"` on tagged installs, `"dev-master"` on branch installs, `"unknown"` if composer runtime data isn't present. Zero maintenance.

## Test plan
- [x] `docker compose -f tests/docker-compose.test.yml run --rm php vendor/bin/phpunit --testsuite unit` → 34/34 green locally
- [x] CI green on this PR

## Note
Pre-existing flake spotted while running this: `tests/ModelTest.php` seeds rows in `TestTable` that don't get torn down between runs. Rerunning phpunit against the same mariadb container fails at line 285. Fresh container passes. Worth adding `tearDown` when ModelTest is next touched — not addressed here (scope discipline).