### PR TITLE
fix(jwt): resolveAuthContext must load app models before constant()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 4.4.3
+
+### Bug Fix: `/jwt/login` fatals on apps with custom `user_model`
+
+When an Application's `user_model` is set to an app-specific DataModel (e.g. `"User"` rather than the default `"KyteUser"`), `JwtEndpoint::resolveAuthContext` called `constant($app->user_model)` to resolve the model definition. But the JWT endpoint dispatches *before* `Api::loadAppModels()` runs in the normal MVC pipeline, so the app-scoped constant wasn't yet defined. In PHP 8+ that's a fatal: `Undefined constant "User"`. Surface to the client was HTTP 500.
+
+HMAC `/Session` login did not hit this because `Api::route()` calls `loadAppModels` before reaching the session controller. JWT's whole point is to bypass that pipeline (login can't require auth), which is what created the gap.
+
+Fix: `resolveAuthContext` now calls `Api::loadAppModels($app)` immediately after retrieving the Application, before referencing the constant. If the app references a name that no DataModel row defines, falls back to `KyteUser` (with an `error_log` breadcrumb) rather than fatal — login then naturally fails at `password_verify`, which is a safer surface than a 500.
+
+No schema changes. Composer upgrade is sufficient.
+
 ## 4.4.2
 
 ### Bug Fix: ErrorHandler crash when `apiContext->key` is a ModelObject

--- a/src/Core/Auth/JwtEndpoint.php
+++ b/src/Core/Auth/JwtEndpoint.php
@@ -335,6 +335,27 @@ final class JwtEndpoint
         }
 
         if ($app->user_model !== null && $app->username_colname !== null && $app->password_colname !== null) {
+            // App-specific DataModel constants ("User", "Customer", etc.) are
+            // registered lazily by Api::loadAppModels when an app context is
+            // detected in the normal MVC pipeline. JwtEndpoint dispatches
+            // BEFORE that pipeline runs, so the constant we want may not
+            // exist yet. Load explicitly to make the constant available.
+            \Kyte\Core\Api::loadAppModels($app);
+
+            if (!defined($app->user_model)) {
+                // loadAppModels couldn't define it (no matching DataModel
+                // row, or the row references a name that wasn't registered).
+                // Fall back to KyteUser rather than fatal — login will then
+                // fail at password_verify, which is the safer surface.
+                error_log("JwtEndpoint: app '{$appIdentifier}' references user_model '{$app->user_model}' but no DataModel row defines it; falling back to KyteUser.");
+                return [
+                    'user_model'     => KyteUser,
+                    'username_field' => $defaultUserField,
+                    'password_field' => $defaultPassField,
+                    'app'            => $app,
+                ];
+            }
+
             return [
                 'user_model'     => constant($app->user_model),
                 'username_field' => (string)$app->username_colname,


### PR DESCRIPTION
## Summary

- Apps with a custom \`user_model\` (e.g. \`user_model='User'\`) get HTTP 500 on \`/jwt/login\`
- Root cause: \`constant(\$app->user_model)\` fatals because the app-scoped constant isn't defined yet at JWT endpoint dispatch time
- HMAC \`/Session\` works because \`Api::route()\` calls \`loadAppModels\` before reaching the session controller. JWT bypasses that pipeline (login can't require auth) → gap.

## Fix

\`resolveAuthContext\` calls \`Api::loadAppModels(\$app)\` immediately after retrieving the app row. Defensive fallback to KyteUser if the constant still isn't defined.

## Test plan

- [x] All 12 existing JwtEndpointTest tests still pass
- [x] Manually reproduced the bug against dev kyte-api.stratis-troika.com (\`JwtEndpoint: Undefined constant "User"\` in php-fpm error log)
- [x] Patch verified locally; ready for composer rollout to dev → ETOM → ORB

Patch v4.4.3. No schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)