### PR TITLE
fix: sensitive toggle on Controller fails with TypeError (metadata-only PUT)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 4.5.2
+
+### Bug Fix: `sensitive` toggle on a Controller silently fails (TypeError on metadata-only PUT)
+
+Completes the 4.5.1 fix for the third meta-controller. Toggling `sensitive=1` on a **Controller** (the detail-page toggle) returned HTTP 200 with an empty body and reverted with "Save failed."
+
+`ControllerController::hook_preprocess` (update) calls `validateControllerUpdate($o, $r)`, which early-returns only when `$o->name === $r['name']`. A metadata-only PUT of `{sensitive:1}` omits `name`, so `$r['name']` is `null`; `"SomeController" === null` is `false`, so it fell through and passed `null` into `checkNameExistsInScope(string $name)` → **TypeError** → caught by the global exception handler (logged as a `KyteError`, hence the empty 200) → the update aborted before `sensitive` was saved.
+
+Fix: `validateControllerUpdate` now returns early when `name` is absent — `if (!isset($r['name']) || $o->name === $r['name'])`. The name-change path (which always sends `name`) is unaffected.
+
+This is the Controller-level sibling of the 4.5.1 DataModel/ModelAttribute fixes — all three meta-controllers assumed every update carried the full record. With 4.5.2, sensitive flags can be set at controller, model, and field level. No schema change.
+
 ## 4.5.1
 
 ### Bug Fix: `sensitive` toggle (and any metadata-only PUT) silently fails on DataModel / ModelAttribute

--- a/src/Mvc/Controller/ControllerController.php
+++ b/src/Mvc/Controller/ControllerController.php
@@ -62,8 +62,14 @@ class ControllerController extends ModelController
      */
     private function validateControllerUpdate($originalController, array $updateData): void
     {
-        // Only validate if the name is actually changing
-        if ($originalController->name === $updateData['name']) {
+        // Skip when the update isn't changing the name. A metadata-only
+        // partial PUT — e.g. the detail page toggling `sensitive` — omits
+        // `name` entirely. The old `=== $updateData['name']` compared the
+        // existing string to null (false), so it fell through and passed
+        // null into checkNameExistsInScope(string $name) -> TypeError ->
+        // swallowed by the exception handler -> empty 200 -> save aborted
+        // before `sensitive` persisted.
+        if (!isset($updateData['name']) || $originalController->name === $updateData['name']) {
             return;
         }
 


### PR DESCRIPTION
## Summary
Completes the 4.5.1 fix for the third meta-controller. Toggling `sensitive=1` on a **Controller** returned 200-empty + "Save failed."

`validateControllerUpdate` early-returned only on `$o->name === $r['name']`. A `{sensitive:1}` PUT omits `name` → `"SomeController" === null` is false → fell through → `checkNameExistsInScope(string $name)` got `null` → **TypeError** → swallowed by the exception handler (logged as KyteError, hence empty 200) → save aborted.

Fix: `if (!isset($r['name']) || $o->name === $r['name']) return;`

Confirmed on ORB via DEBUG_SQL: `PUT Controller id=46 {sensitive:1}` logged exactly this TypeError at ControllerController.php:70.

## Test plan
- [ ] Deploy to ORB; toggle Controller sensitive → "Saved", DB `sensitive=1`, non-empty response
- [x] Name-change path unaffected (still sends `name`)

Target v4.5.2. No schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)