### PR TITLE
JWT-mode anonymous/public API access — AppContextStrategy (KYTE-#229)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,18 @@ Lets a site running in **JWT auth mode** (endpoint + appId, no embedded HMAC key
 
 Audit attribution for anonymous requests uses `user_id=null` / session `'0'` (ActivityLogger already tolerates a null user). Existing HMAC and JWT-Bearer flows are unchanged. Tests: `tests/AppContextStrategyTest.php` (matches() truth table; `preAuth` resolves account but not user/hasSession; tri-state opt-in enforcement incl. unknown values treated as off).
 
+### Feature: platform-level password reset for JWT mode — `/jwt/password-*` (KYTE-#268)
+
+Shipyard is **platform-level** (no `x-kyte-appid` — `applicationId` is deliberately null), so its anonymous password reset can ride neither HMAC anonymous (gone in JWT mode) nor `AppContextStrategy` (appid required). Result: password reset was broken on JWT-mode Shipyard installs. Fixed the same way `/jwt/login` solved appid-less login — dedicated unauthenticated endpoints on `JwtEndpoint`:
+
+- `POST /jwt/password-reset` `{email}` → always `{ok:true}` (no-reveal); known email gets a timestamped token (raw, in the password column — login disabled while pending) + SES mail.
+- `POST /jwt/password-validate` `{token}` → `{valid:bool}` (password.html pre-check).
+- `POST /jwt/password-update` `{token, password}` → consumes the token, stores the new password hashed, and **revokes every refresh-token family** for the user (a reset invalidates all sessions); `401 invalid_token` on expired/unknown.
+
+Token/email mechanics are extracted to `Kyte\Core\Auth\PasswordResetFlow` and shared with `KytePasswordResetController` (behavior-identical refactor — same token format, 1-hour TTL, no-reveal logging), so the HMAC/app-scoped path and the JWT platform path cannot drift. App-scoped sites keep using their own reset controllers via `app_context` mode 2. kyte-shipyard `reset.js`/`password.js` call the new endpoints when in JWT mode (ships in the Shipyard release alongside).
+
+Tests: `tests/JwtEndpointTest.php` gains the `/jwt/password-*` suite (no-reveal, pending-token login lockout, validate/consume round-trip, refresh-family revocation, expired/unknown → 401).
+
 ## 4.10.1
 
 ### Fix: MCP commit_draft published raw bzip2 bytes into page HTML (header/footer section CSS not decompressed)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,13 @@ Lets a site running in **JWT auth mode** (endpoint + appId, no embedded HMAC key
 - `preAuth()` resolves the application's **account** for query scoping but **never resolves a user and never sets `hasSession`**. That is the security invariant: `ModelController::authenticate()` throws unless both `$api->user->id` and `$api->session->hasSession` are set, so every `requireAuth=true` controller keeps returning 403 to anonymous requests — only `requireAuth=false` controllers are reachable.
 
 **Defense in depth:**
-- **Per-app opt-in.** New `Application.allow_public` flag (default `0`; migration `migrations/4.11.0_application_allow_public.sql`). `preAuth()` rejects an appid-only request unless the app sets `allow_public=1` — anonymous access is never implicit.
-- **Read-only.** `ModelController` restricts an `app_context` request to `GET` regardless of the controller's `allowableActions`; anonymous writes are not possible.
+- **Per-app tri-state opt-in.** New `Application.allow_public` flag (default `0`; migration `migrations/4.11.0_application_allow_public.sql`):
+  - `0` (default) — anonymous appid-only requests are rejected in `preAuth()`; anonymous access is never implicit.
+  - `1` — **read-only**: `ModelController` restricts an `app_context` request to `GET` regardless of the controller's `allowableActions` (public catalog/storefront browsing).
+  - `2` — **controller-governed**: the controller's own `requireAuth=false` + `allowableActions` declaration governs, including writes — needed for pre-login flows like password reset (`new`/`update` are POST/PUT). This matches the contract controller authors have always written against: under HMAC, anonymous visitors to a public site can already reach every `requireAuth=false` action (the signing endpoint mints anonymous signatures from the embedded public key alone), so `2` exposes nothing HMAC does not. `requireAuth=true` controllers still 403 in every mode (the no-user/no-`hasSession` invariant is independent of `allow_public`).
 - **Shadow harness.** `AuthShadowHarness` skips `app_context` (no legacy equivalent to diff against during dispatcher rollout).
 
-Audit attribution for anonymous requests uses `user_id=null` / session `'0'` (ActivityLogger already tolerates a null user). Existing HMAC and JWT-Bearer flows are unchanged. Tests: `tests/AppContextStrategyTest.php` (matches() truth table; `preAuth` resolves account but not user/hasSession; opt-in enforcement).
+Audit attribution for anonymous requests uses `user_id=null` / session `'0'` (ActivityLogger already tolerates a null user). Existing HMAC and JWT-Bearer flows are unchanged. Tests: `tests/AppContextStrategyTest.php` (matches() truth table; `preAuth` resolves account but not user/hasSession; tri-state opt-in enforcement incl. unknown values treated as off).
 
 ## 4.10.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+## 4.11.0
+
+### Feature: JWT-mode anonymous/public API access (AppContextStrategy) — KYTE-#229
+
+Lets a site running in **JWT auth mode** (endpoint + appId, no embedded HMAC key/secret) serve `requireAuth=false` controllers to **anonymous visitors** (public/catalog browsing before any login) — something only HMAC mode could do before. Server-side half of the two-repo change (the kyte-api-js anonymous fall-through ships alongside).
+
+**New `AppContextStrategy`** (`src/Core/Auth/AppContextStrategy.php`), slotted in `AuthDispatcher::buildDefault()` **after** `JwtSessionStrategy` and **before** `HmacSessionStrategy`:
+- `matches()` is strict and header-only — claims a request **only** when an `x-kyte-appid` is present **and** there is no `Authorization` Bearer, no `x-kyte-signature`, and no `x-kyte-identity`. Mutually exclusive with every authenticated flow, so it cannot shadow HMAC or JWT.
+- `preAuth()` resolves the application's **account** for query scoping but **never resolves a user and never sets `hasSession`**. That is the security invariant: `ModelController::authenticate()` throws unless both `$api->user->id` and `$api->session->hasSession` are set, so every `requireAuth=true` controller keeps returning 403 to anonymous requests — only `requireAuth=false` controllers are reachable.
+
+**Defense in depth:**
+- **Per-app opt-in.** New `Application.allow_public` flag (default `0`; migration `migrations/4.11.0_application_allow_public.sql`). `preAuth()` rejects an appid-only request unless the app sets `allow_public=1` — anonymous access is never implicit.
+- **Read-only.** `ModelController` restricts an `app_context` request to `GET` regardless of the controller's `allowableActions`; anonymous writes are not possible.
+- **Shadow harness.** `AuthShadowHarness` skips `app_context` (no legacy equivalent to diff against during dispatcher rollout).
+
+Audit attribution for anonymous requests uses `user_id=null` / session `'0'` (ActivityLogger already tolerates a null user). Existing HMAC and JWT-Bearer flows are unchanged. Tests: `tests/AppContextStrategyTest.php` (matches() truth table; `preAuth` resolves account but not user/hasSession; opt-in enforcement).
+
 ## 4.10.1
 
 ### Fix: MCP commit_draft published raw bzip2 bytes into page HTML (header/footer section CSS not decompressed)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ Audit attribution for anonymous requests uses `user_id=null` / session `'0'` (Ac
 Shipyard is **platform-level** (no `x-kyte-appid` — `applicationId` is deliberately null), so its anonymous password reset can ride neither HMAC anonymous (gone in JWT mode) nor `AppContextStrategy` (appid required). Result: password reset was broken on JWT-mode Shipyard installs. Fixed the same way `/jwt/login` solved appid-less login — dedicated unauthenticated endpoints on `JwtEndpoint`:
 
 - `POST /jwt/password-reset` `{email}` → always `{ok:true}` (no-reveal); known email gets a timestamped token (raw, in the password column — login disabled while pending) + SES mail.
-- `POST /jwt/password-validate` `{token}` → `{valid:bool}` (password.html pre-check).
+- `POST /jwt/password-validate` `{token}` → `{valid:bool, email}` (password.html pre-check; the email is only disclosed to a live-token holder, who received it at that inbox).
 - `POST /jwt/password-update` `{token, password}` → consumes the token, stores the new password hashed, and **revokes every refresh-token family** for the user (a reset invalidates all sessions); `401 invalid_token` on expired/unknown.
 
 Token/email mechanics are extracted to `Kyte\Core\Auth\PasswordResetFlow` and shared with `KytePasswordResetController` (behavior-identical refactor — same token format, 1-hour TTL, no-reveal logging), so the HMAC/app-scoped path and the JWT platform path cannot drift. App-scoped sites keep using their own reset controllers via `app_context` mode 2. kyte-shipyard `reset.js`/`password.js` call the new endpoints when in JWT mode (ships in the Shipyard release alongside).

--- a/migrations/4.11.0_application_allow_public.sql
+++ b/migrations/4.11.0_application_allow_public.sql
@@ -1,0 +1,19 @@
+-- =========================================================================
+-- Kyte v4.11.0 - add Application.allow_public (JWT-mode anonymous access)
+-- =========================================================================
+-- IMPORTANT: Backup your database before running this migration.
+--
+-- Adds the per-app opt-in flag for anonymous/public API access via
+-- AppContextStrategy (JWT-mode public storefronts). Default 0 = anonymous
+-- appid-only requests are rejected; set to 1 per app to allow read-only
+-- anonymous access to requireAuth=false controllers.
+--
+-- ADDITIVE / migration-first / inert on older code (older code ignores the
+-- column; new code defaults it to 0). Table name is PascalCase. ALGORITHM not
+-- pinned (engine auto-selects INSTANT for ADD COLUMN where available).
+--
+-- See src/Mvc/Model/Application.php + src/Core/Auth/AppContextStrategy.php.
+-- =========================================================================
+
+ALTER TABLE `Application`
+    ADD COLUMN `allow_public` INT UNSIGNED NOT NULL DEFAULT 0;

--- a/migrations/4.11.0_application_allow_public.sql
+++ b/migrations/4.11.0_application_allow_public.sql
@@ -4,9 +4,11 @@
 -- IMPORTANT: Backup your database before running this migration.
 --
 -- Adds the per-app opt-in flag for anonymous/public API access via
--- AppContextStrategy (JWT-mode public storefronts). Default 0 = anonymous
--- appid-only requests are rejected; set to 1 per app to allow read-only
--- anonymous access to requireAuth=false controllers.
+-- AppContextStrategy (JWT-mode public storefronts). Tri-state:
+--   0 = anonymous appid-only requests rejected (default);
+--   1 = read-only (GET) anonymous access to requireAuth=false controllers;
+--   2 = controller-governed — requireAuth=false + allowableActions apply,
+--       including writes (password reset / signup-style public flows).
 --
 -- ADDITIVE / migration-first / inert on older code (older code ignores the
 -- column; new code defaults it to 0). Table name is PascalCase. ALGORITHM not

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -4,6 +4,7 @@
     <testsuite name="unit">
       <file>tests/ActivityLoggerSensitivityTest.php</file>
       <file>tests/ApiTest.php</file>
+      <file>tests/AppContextStrategyTest.php</file>
       <file>tests/Bz2CodecTest.php</file>
       <file>tests/ClientIpTest.php</file>
       <file>tests/DatabaseTest.php</file>

--- a/src/Core/Auth/AppContextStrategy.php
+++ b/src/Core/Auth/AppContextStrategy.php
@@ -20,12 +20,20 @@ use Kyte\Exception\SessionException;
  * BOTH `$api->user->id` and `$api->session->hasSession` are set, so every
  * `requireAuth=true` controller keeps returning 403 to anonymous requests.
  * Only controllers that explicitly opt out (`requireAuth=false`) are
- * reachable, and even those are READ-ONLY for this path (ModelController
- * restricts an app_context request to GET).
+ * reachable.
  *
- * Per-app opt-in: an application must set `Application.allow_public = 1` to
- * serve anonymous requests. A non-opted-in app's appid-only request is
- * rejected in preAuth (so anonymous access is never silently enabled).
+ * Per-app opt-in (tri-state `Application.allow_public`):
+ *   0 = off (default) — appid-only requests are rejected in preAuth, so
+ *       anonymous access is never silently enabled.
+ *   1 = read-only — ModelController restricts the request to GET regardless
+ *       of the controller's allowableActions (public catalog/storefront).
+ *   2 = controller-governed — the controller's own `requireAuth=false` +
+ *       `allowableActions` declaration governs, including writes (e.g.
+ *       password reset / signup flows). This is the same contract controller
+ *       authors have always written against: under HMAC, anonymous visitors
+ *       to a public site could always reach every requireAuth=false action
+ *       (the signing endpoint mints anonymous signatures from the embedded
+ *       public key alone), so 2 exposes nothing HMAC did not.
  *
  * matches() is STRICT and header-only: it claims a request ONLY when an
  * `x-kyte-appid` is present AND there is no Authorization Bearer, no
@@ -75,9 +83,12 @@ class AppContextStrategy implements AuthStrategy
             throw new SessionException('Anonymous access requires a valid application context (x-kyte-appid).');
         }
 
-        // Per-app opt-in. Without an explicit Application.allow_public=1, an
-        // appid-only request is rejected — anonymous access is never implicit.
-        if ((int)($api->app->allow_public ?? 0) !== 1) {
+        // Per-app opt-in. Without an explicit Application.allow_public of
+        // 1 (read-only) or 2 (controller-governed), an appid-only request is
+        // rejected — anonymous access is never implicit. The read-only vs
+        // controller-governed distinction is enforced in ModelController.
+        $allowPublic = (int)($api->app->allow_public ?? 0);
+        if ($allowPublic !== 1 && $allowPublic !== 2) {
             throw new SessionException('Anonymous access is not enabled for this application.');
         }
 

--- a/src/Core/Auth/AppContextStrategy.php
+++ b/src/Core/Auth/AppContextStrategy.php
@@ -1,0 +1,142 @@
+<?php
+namespace Kyte\Core\Auth;
+
+use Kyte\Core\Api;
+use Kyte\Core\ModelObject;
+use Kyte\Exception\SessionException;
+
+/**
+ * Anonymous application-context strategy — JWT-mode public/anonymous access.
+ *
+ * Lets a site running in JWT auth mode (endpoint + appId, no embedded HMAC
+ * key/secret) serve `requireAuth=false` controllers to ANONYMOUS visitors
+ * (no user, before any login) using only the `x-kyte-appid` header — no
+ * Bearer, no HMAC identity/signature. This closes the gap where JWT mode
+ * could not serve public/catalog browsing the way HMAC mode can.
+ *
+ * SECURITY INVARIANT (load-bearing): preAuth() resolves the application's
+ * ACCOUNT for query scoping but deliberately resolves NO user and NEVER sets
+ * `$api->session->hasSession`. ModelController::authenticate() throws unless
+ * BOTH `$api->user->id` and `$api->session->hasSession` are set, so every
+ * `requireAuth=true` controller keeps returning 403 to anonymous requests.
+ * Only controllers that explicitly opt out (`requireAuth=false`) are
+ * reachable, and even those are READ-ONLY for this path (ModelController
+ * restricts an app_context request to GET).
+ *
+ * Per-app opt-in: an application must set `Application.allow_public = 1` to
+ * serve anonymous requests. A non-opted-in app's appid-only request is
+ * rejected in preAuth (so anonymous access is never silently enabled).
+ *
+ * matches() is STRICT and header-only: it claims a request ONLY when an
+ * `x-kyte-appid` is present AND there is no Authorization Bearer, no
+ * `x-kyte-signature`, and no `x-kyte-identity`. That is mutually exclusive
+ * with every authenticated flow, so it can never shadow HMAC or JWT. Slotted
+ * in AuthDispatcher AFTER JwtSessionStrategy and BEFORE HmacSessionStrategy.
+ */
+class AppContextStrategy implements AuthStrategy
+{
+    public function name(): string
+    {
+        return 'app_context';
+    }
+
+    /**
+     * Claim only genuine anonymous app-only requests: an appid is present and
+     * NO authenticated credential (Bearer / HMAC signature / HMAC identity)
+     * accompanies it. Pure header inspection, no side effects.
+     */
+    public function matches(): bool
+    {
+        if (empty($_SERVER['HTTP_X_KYTE_APPID'])) {
+            return false;
+        }
+        // A Bearer token belongs to McpToken or Jwt; an identity/signature
+        // belongs to Hmac. If any is present, this is not an anonymous request.
+        if ($this->authorizationHeader() !== null) {
+            return false;
+        }
+        if (!empty($_SERVER['HTTP_X_KYTE_SIGNATURE'])) {
+            return false;
+        }
+        if (!empty($_SERVER['HTTP_X_KYTE_IDENTITY'])) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Establish anonymous application context: resolve the account from the
+     * already-resolved app (Api::route() resolves $api->app from x-kyte-appid
+     * before auth). Resolves NO user and never sets hasSession.
+     */
+    public function preAuth(Api $api): void
+    {
+        if ($api->app === null || $api->appId === null) {
+            throw new SessionException('Anonymous access requires a valid application context (x-kyte-appid).');
+        }
+
+        // Per-app opt-in. Without an explicit Application.allow_public=1, an
+        // appid-only request is rejected — anonymous access is never implicit.
+        if ((int)($api->app->allow_public ?? 0) !== 1) {
+            throw new SessionException('Anonymous access is not enabled for this application.');
+        }
+
+        // Resolve the account from the application for query scoping only.
+        $account = new ModelObject(KyteAccount);
+        if (!$account->retrieve('id', (int)$api->app->kyte_account)) {
+            throw new SessionException('Unable to resolve account for application.');
+        }
+        $api->account = $account;
+
+        // Anonymous response markers. NOT setting $api->user->id and NOT
+        // touching $api->session->hasSession is the security invariant.
+        $api->response['session'] = '0';
+        $api->response['uid'] = '0';
+
+        // Language resolution from account/app only (no user).
+        $finalLanguage = defined('APP_LANG') ? APP_LANG : 'en';
+        if (isset($api->account->default_language) && !empty($api->account->default_language)) {
+            $finalLanguage = $api->account->default_language;
+        }
+        if (isset($api->app->language) && !empty($api->app->language)) {
+            $finalLanguage = $api->app->language;
+        }
+        \Kyte\Util\I18n::setLanguage($finalLanguage);
+    }
+
+    /**
+     * No signature/token to verify — anonymous app context is fully
+     * established in preAuth.
+     */
+    public function verify(Api $api): void
+    {
+    }
+
+    /**
+     * Read the Authorization header across the SAPI variants (mirrors
+     * JwtSessionStrategy / McpTokenStrategy).
+     */
+    private function authorizationHeader(): ?string
+    {
+        $candidates = [
+            $_SERVER['HTTP_AUTHORIZATION'] ?? null,
+            $_SERVER['REDIRECT_HTTP_AUTHORIZATION'] ?? null,
+        ];
+        foreach ($candidates as $value) {
+            if (is_string($value) && $value !== '') {
+                return $value;
+            }
+        }
+        if (\function_exists('apache_request_headers')) {
+            $headers = \apache_request_headers();
+            if (is_array($headers)) {
+                foreach ($headers as $hname => $value) {
+                    if (strcasecmp($hname, 'Authorization') === 0 && is_string($value) && $value !== '') {
+                        return $value;
+                    }
+                }
+            }
+        }
+        return null;
+    }
+}

--- a/src/Core/Auth/AuthDispatcher.php
+++ b/src/Core/Auth/AuthDispatcher.php
@@ -52,6 +52,10 @@ class AuthDispatcher
      *
      * Phase 2 (MCP) added McpTokenStrategy.
      * Phase 3 (JWT) appended JwtSessionStrategy between MCP and HMAC.
+     * Phase 3 follow-on added AppContextStrategy between Jwt and HMAC — it
+     * claims ONLY anonymous app-only requests (x-kyte-appid, no Bearer/
+     * signature/identity), so it cannot shadow the authenticated flows above
+     * or the HMAC catch-all below.
      * Each is opt-in by config: a token can only be claimed by a
      * strategy that's actually configured on the install.
      */
@@ -60,6 +64,7 @@ class AuthDispatcher
         return new self([
             new McpTokenStrategy(),
             new JwtSessionStrategy(),
+            new AppContextStrategy(),
             new HmacSessionStrategy(),
         ]);
     }

--- a/src/Core/Auth/AuthShadowHarness.php
+++ b/src/Core/Auth/AuthShadowHarness.php
@@ -53,6 +53,14 @@ class AuthShadowHarness
         try {
             $strategy = AuthDispatcher::buildDefault()->select();
             if ($strategy !== null) {
+                // AppContextStrategy (anonymous app-only) has no legacy
+                // equivalent — the legacy HMAC path rejects appid-only
+                // requests outright — so there is nothing to compare. Skip to
+                // avoid spurious shadow diffs/exceptions during rollout. The
+                // finally block still restores the pre-shadow Api state.
+                if ($strategy->name() === 'app_context') {
+                    return;
+                }
                 $strategy->preAuth($api);
                 $strategy->verify($api);
             }

--- a/src/Core/Auth/JwtEndpoint.php
+++ b/src/Core/Auth/JwtEndpoint.php
@@ -29,6 +29,24 @@ use Kyte\Exception\SessionException;
  *                          Revokes EVERY active refresh token for the
  *                          user whose token was presented.
  *
+ *   POST /jwt/password-reset    body {email}
+ *                          → 200 {ok: true}  ALWAYS (never reveals
+ *                                whether the email exists)
+ *   POST /jwt/password-validate body {token}
+ *                          → 200 {valid: bool}
+ *   POST /jwt/password-update   body {token, password}
+ *                          → 200 {ok: true}; revokes all the user's
+ *                                refresh-token families
+ *                          → 401 invalid/expired token
+ *                          Platform-level (KyteUser) password reset for
+ *                          JWT-mode Shipyard (KYTE-#268). Shipyard is not
+ *                          app-scoped (no x-kyte-appid), so neither HMAC
+ *                          anonymous nor AppContextStrategy (#229) can
+ *                          carry this flow in JWT mode — these endpoints
+ *                          solve it the same way /jwt/login solved
+ *                          appid-less login. App-scoped sites use their
+ *                          own controllers via app_context mode 2.
+ *
  * Routing: Api::route() detects a `/jwt` first segment and dispatches
  * here before the normal MVC pipeline runs (same pattern as /mcp).
  *
@@ -115,6 +133,9 @@ final class JwtEndpoint
                 case 'refresh':    return self::refresh($body, $ip);
                 case 'logout':     return self::logout($body);
                 case 'logout-all': return self::logoutAll($body);
+                case 'password-reset':    return self::passwordReset($body);
+                case 'password-validate': return self::passwordValidate($body);
+                case 'password-update':   return self::passwordUpdate($body);
                 default:
                     return self::error(404, 'not_found', "Unknown JWT endpoint: {$action}.");
             }
@@ -351,6 +372,97 @@ final class JwtEndpoint
             'logout_all'
         );
         return self::success(['ok' => true, 'revoked' => $count]);
+    }
+
+    /**
+     * Request a password reset (KYTE-#268). Platform-level: operates on
+     * KyteUser only — app-scoped sites run their own reset controllers
+     * via app_context mode 2. ALWAYS answers {ok:true} so an anonymous
+     * caller can't probe which emails exist (mirrors
+     * KytePasswordResetController::new).
+     */
+    private static function passwordReset(array $body): array
+    {
+        $email = trim((string)($body['email'] ?? ''));
+        if ($email === '') {
+            return self::error(400, 'invalid_request', 'email required.');
+        }
+
+        $user = new ModelObject(KyteUser);
+        if ($user->retrieve('email', $email)) {
+            $token = PasswordResetFlow::generateToken($email);
+
+            // The RAW token goes into the password column (see
+            // PasswordResetFlow) — ModelObject::save writes raw, and a
+            // pending token also disables login until the reset completes.
+            $user->save(['password' => $token]);
+
+            try {
+                PasswordResetFlow::sendResetEmail($user, $token);
+            } catch (\Throwable $e) {
+                // Delivery state must not leak to an anonymous caller —
+                // log it and keep the no-reveal response shape.
+                error_log('JwtEndpoint: password-reset email failed - ' . $e->getMessage());
+            }
+        } else {
+            // Same no-reveal logging as the HMAC controller path.
+            error_log('Attempted reset for non-existing account ' . $email);
+        }
+
+        return self::success(['ok' => true]);
+    }
+
+    /**
+     * Validate a reset token without consuming it — password.html checks
+     * the token from the email link before showing the new-password form.
+     */
+    private static function passwordValidate(array $body): array
+    {
+        $token = (string)($body['token'] ?? '');
+        if ($token === '') {
+            return self::error(400, 'invalid_request', 'token required.');
+        }
+
+        $user = new ModelObject(KyteUser);
+        $valid = $user->retrieve('password', $token)
+            && PasswordResetFlow::isValidToken($token, (string)$user->password);
+
+        return self::success(['valid' => $valid]);
+    }
+
+    /**
+     * Consume a reset token and set the new password. Revokes every
+     * refresh-token family for the user — a password reset invalidates
+     * all existing sessions.
+     */
+    private static function passwordUpdate(array $body): array
+    {
+        $token = (string)($body['token'] ?? '');
+        $password = (string)($body['password'] ?? '');
+        if ($token === '' || $password === '') {
+            return self::error(400, 'invalid_request', 'token and password required.');
+        }
+
+        $user = new ModelObject(KyteUser);
+        if (!$user->retrieve('password', $token)
+            || !PasswordResetFlow::isValidToken($token, (string)$user->password)) {
+            return self::error(401, 'invalid_token', 'Invalid or expired token. Please request a new password reset.');
+        }
+
+        // ModelObject::save writes raw — hash explicitly here (the
+        // struct-driven password_hash lives in ModelController's data
+        // cleaning, which this path doesn't traverse).
+        $user->save(['password' => password_hash($password, PASSWORD_DEFAULT)]);
+
+        // Best-effort session revocation; the password change itself
+        // already succeeded.
+        try {
+            RefreshTokenStore::revokeAllForUser((int)$user->id, (int)$user->kyte_account, 'password_reset');
+        } catch (\Throwable $e) {
+            error_log('JwtEndpoint: refresh-token revocation after password reset failed - ' . $e->getMessage());
+        }
+
+        return self::success(['ok' => true]);
     }
 
     /**

--- a/src/Core/Auth/JwtEndpoint.php
+++ b/src/Core/Auth/JwtEndpoint.php
@@ -427,7 +427,13 @@ final class JwtEndpoint
         $valid = $user->retrieve('password', $token)
             && PasswordResetFlow::isValidToken($token, (string)$user->password);
 
-        return self::success(['valid' => $valid]);
+        // The email is only disclosed to a caller holding a LIVE token —
+        // which they could only have received at that very inbox.
+        // password.html uses it to fill the read-only email field.
+        return self::success([
+            'valid' => $valid,
+            'email' => $valid ? (string)$user->email : null,
+        ]);
     }
 
     /**

--- a/src/Core/Auth/PasswordResetFlow.php
+++ b/src/Core/Auth/PasswordResetFlow.php
@@ -1,0 +1,289 @@
+<?php
+namespace Kyte\Core\Auth;
+
+use Kyte\Core\ModelObject;
+
+/**
+ * Shared password-reset mechanics (KYTE-#268).
+ *
+ * Two surfaces drive the same reset flow and must stay byte-compatible:
+ *
+ *   - KytePasswordResetController — the legacy model-CRUD path (HMAC
+ *     anonymous, and app_context mode 2 for app-scoped sites).
+ *   - JwtEndpoint /jwt/password-* — the platform-level JWT-mode path
+ *     (Shipyard is not app-scoped, so it cannot ride AppContextStrategy).
+ *
+ * Mechanics (unchanged from the original controller implementation):
+ *   - Token format: `<uniqueHex>.<unixTimestamp>`, capped at 255 chars
+ *     (the KyteUser.password column size).
+ *   - The RAW token is stored in the user's password column. That is
+ *     deliberate: ModelObject::save() writes raw (the struct-driven
+ *     password_hash lives in ModelController's data cleaning), and a
+ *     pending raw token also disables login until the reset completes,
+ *     because password_verify() can never match a non-hash.
+ *   - Tokens expire after TOKEN_TTL_SECONDS (1 hour).
+ */
+final class PasswordResetFlow
+{
+    public const TOKEN_TTL_SECONDS = 3600;
+
+    /**
+     * Generate a timestamped reset token for the given email.
+     * Format: uniqueToken.timestamp
+     */
+    public static function generateToken(string $email): string
+    {
+        // Generate unique token part
+        $randomBytes = random_bytes(24); // Reduced to 24 bytes to leave room for timestamp
+        $emailHash = hash('sha256', $email, true);
+        $tokenData = $emailHash . $randomBytes;
+        $uniqueToken = bin2hex($tokenData);
+
+        // Add timestamp
+        $timestamp = time();
+        $token = $uniqueToken . '.' . $timestamp;
+
+        // Ensure token length is within 255 character limit
+        if (strlen($token) > 255) {
+            // If too long, truncate the unique part but keep the timestamp
+            $maxUniqueLength = 255 - strlen('.' . $timestamp);
+            $uniqueToken = substr($uniqueToken, 0, $maxUniqueLength);
+            $token = $uniqueToken . '.' . $timestamp;
+        }
+
+        return $token;
+    }
+
+    /**
+     * Validate token format, expiration, and match with the stored token
+     * (the raw value currently in the user's password column).
+     */
+    public static function isValidToken(string $providedToken, ?string $storedToken): bool
+    {
+        // Check if stored token exists
+        if (empty($storedToken)) {
+            return false;
+        }
+
+        // Check if provided token matches stored token
+        if ($storedToken !== $providedToken) {
+            return false;
+        }
+
+        // Extract timestamp from token
+        $tokenParts = explode('.', $providedToken);
+        if (count($tokenParts) !== 2) {
+            return false; // Invalid token format
+        }
+
+        $timestamp = (int)$tokenParts[1];
+        $tokenAge = time() - $timestamp;
+
+        // Check if token is expired
+        if ($tokenAge > self::TOKEN_TTL_SECONDS) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Send the reset email via SES. Requires APP_SES_REGION, APP_EMAIL,
+     * and SHIPYARD_URL. Throws on configuration/delivery failure — the
+     * caller decides whether that is fatal (HMAC controller) or logged
+     * (JWT endpoint, which must not reveal delivery state anonymously).
+     */
+    public static function sendResetEmail(ModelObject $user, string $token): void
+    {
+        $body = self::emailHtml($user, $token);
+
+        $credentials = new \Kyte\Aws\Credentials(APP_SES_REGION);
+        $ses = new \Kyte\Aws\Ses($credentials, 'Kyte Shipyard <' . APP_EMAIL . '>');
+        $ses->send([$user->email], "Kyte Shipyard - Password Reset Instructions", $body);
+    }
+
+    /**
+     * Generate the HTML email body for the password reset message.
+     */
+    public static function emailHtml(ModelObject $user, string $token): string
+    {
+        $userName = htmlspecialchars($user->name ?: 'there');
+        $userEmail = htmlspecialchars($user->email);
+        $resetUrl = SHIPYARD_URL . '/password.html?token=' . urlencode($token);
+        $resetUrlDisplay = htmlspecialchars($resetUrl);
+
+        return '<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Kyte Shipyard - Password Reset</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, \'Segoe UI\', Roboto, Helvetica, Arial, sans-serif;
+            line-height: 1.6;
+            color: #333;
+            max-width: 600px;
+            margin: 0 auto;
+            padding: 20px;
+            background-color: #f8f9fa;
+        }
+        .email-container {
+            background-color: white;
+            border-radius: 8px;
+            padding: 40px;
+            box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        }
+        .header {
+            text-align: center;
+            margin-bottom: 30px;
+        }
+        .logo {
+            font-size: 28px;
+            font-weight: bold;
+            color: #2563eb;
+            margin-bottom: 10px;
+        }
+        .subtitle {
+            color: #6b7280;
+            font-size: 16px;
+        }
+        .content {
+            margin-bottom: 30px;
+        }
+        .greeting {
+            font-size: 18px;
+            margin-bottom: 20px;
+            color: #1f2937;
+        }
+        .message {
+            margin-bottom: 25px;
+            color: #4b5563;
+            line-height: 1.7;
+        }
+        .reset-button {
+            display: inline-block;
+            background-color: #2563eb;
+            color: white;
+            padding: 14px 30px;
+            text-decoration: none;
+            border-radius: 6px;
+            font-weight: 600;
+            font-size: 16px;
+            margin: 20px 0;
+            transition: background-color 0.3s ease;
+        }
+        .reset-button:hover {
+            background-color: #1d4ed8;
+        }
+        .button-container {
+            text-align: center;
+            margin: 30px 0;
+        }
+        .alternative-link {
+            background-color: #f3f4f6;
+            border: 1px solid #d1d5db;
+            border-radius: 4px;
+            padding: 12px;
+            font-family: monospace;
+            font-size: 14px;
+            word-break: break-all;
+            color: #374151;
+            margin: 15px 0;
+        }
+        .security-notice {
+            background-color: #fef3c7;
+            border-left: 4px solid #f59e0b;
+            padding: 15px;
+            margin: 25px 0;
+            border-radius: 4px;
+        }
+        .security-notice h4 {
+            margin: 0 0 8px 0;
+            color: #92400e;
+            font-size: 16px;
+        }
+        .security-notice p {
+            margin: 0;
+            color: #78350f;
+            font-size: 14px;
+        }
+        .footer {
+            margin-top: 40px;
+            padding-top: 20px;
+            border-top: 1px solid #e5e7eb;
+            text-align: center;
+            color: #6b7280;
+            font-size: 14px;
+        }
+        .footer p {
+            margin: 5px 0;
+        }
+        @media (max-width: 600px) {
+            body {
+                padding: 10px;
+            }
+            .email-container {
+                padding: 20px;
+            }
+            .reset-button {
+                display: block;
+                text-align: center;
+                width: 100%;
+                box-sizing: border-box;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="email-container">
+        <div class="header">
+            <div class="logo">⚓ Kyte Shipyard</div>
+            <div class="subtitle">Password Reset Request</div>
+        </div>
+
+        <div class="content">
+            <div class="greeting">
+                Hello ' . $userName . ',
+            </div>
+
+            <div class="message">
+                We received a request to reset the password for your Kyte Shipyard account associated with <strong>' . $userEmail . '</strong>.
+            </div>
+
+            <div class="message">
+                Click the button below to reset your password. This link will expire in 1 hour for your security.
+            </div>
+
+            <div class="button-container">
+                <a href="' . $resetUrl . '" class="reset-button">
+                    Reset My Password
+                </a>
+            </div>
+
+            <div class="message">
+                If the button above doesn\'t work, you can copy and paste this link into your browser:
+            </div>
+
+            <div class="alternative-link">
+                ' . $resetUrlDisplay . '
+            </div>
+
+            <div class="security-notice">
+                <h4>🔒 Security Notice</h4>
+                <p>If you didn\'t request this password reset, please ignore this email. For security reasons, this reset link will expire in 1 hour and you will need to generate a new request if it expires.</p>
+            </div>
+        </div>
+
+        <div class="footer">
+            <p><strong>Kyte Shipyard Team</strong></p>
+            <p>This is an automated message, please do not reply to this email.</p>
+            <p style="margin-top: 15px; font-size: 12px; color: #9ca3af;">
+                If you\'re having trouble with the reset process, please contact our support team.
+            </p>
+        </div>
+    </div>
+</body>
+</html>';
+    }
+}

--- a/src/Mvc/Controller/KytePasswordResetController.php
+++ b/src/Mvc/Controller/KytePasswordResetController.php
@@ -2,6 +2,8 @@
 
 namespace Kyte\Mvc\Controller;
 
+use Kyte\Core\Auth\PasswordResetFlow;
+
 class KytePasswordResetController extends ModelController
 {
     public function hook_init() {
@@ -15,11 +17,11 @@ class KytePasswordResetController extends ModelController
         switch ($method) {
             case 'update':
                 // Check if token exists and is valid
-                if (!isset($r['token']) || !$this->isValidToken($r['token'], $o)) {
+                if (!isset($r['token']) || !PasswordResetFlow::isValidToken((string)$r['token'], $o->password ?? null)) {
                     throw new \Exception("Invalid or expired token. Please request a new password reset.");
                 }
                 break;
-            
+
             default:
                 break;
         }
@@ -30,7 +32,7 @@ class KytePasswordResetController extends ModelController
             case 'get':
                 $field = 'password';
                 break;
-            
+
             default:
                 break;
         }
@@ -45,19 +47,16 @@ class KytePasswordResetController extends ModelController
 
         $user = new \Kyte\Core\ModelObject($this->model);
         if ($user->retrieve('email', $data['email'])) {
-            // Generate secure token with timestamp
-            $token = $this->generateTimestampedToken($user->email);
+            // Generate secure token with timestamp. Token/email mechanics are
+            // shared with the JWT-mode /jwt/password-* endpoints (KYTE-#268)
+            // — see PasswordResetFlow.
+            $token = PasswordResetFlow::generateToken($user->email);
 
             $data['password'] = $token;
             $user->save($data);
 
-            // Generate HTML email body
-            $body = $this->generatePasswordResetEmailHtml($user, $token);
-
             // Send email
-            $credentials = new \Kyte\Aws\Credentials(APP_SES_REGION);
-            $ses = new \Kyte\Aws\Ses($credentials, 'Kyte Shipyard <'.APP_EMAIL.'>');
-            $ses->send([$user->email], "Kyte Shipyard - Password Reset Instructions", $body);
+            PasswordResetFlow::sendResetEmail($user, $token);
 
         } else {
             // no need to report if account doesn't exist as we don't need people probing - TODO: possibly setup alert to see how often this happens
@@ -65,258 +64,5 @@ class KytePasswordResetController extends ModelController
         }
 
         $this->response['data'] = $response;
-    }
-
-    /**
-     * Generate a timestamped token for password reset
-     * Format: uniqueToken.timestamp
-     * 
-     * @param string $email User's email address
-     * @return string Timestamped token
-     */
-    private function generateTimestampedToken($email) {
-        // Generate unique token part
-        $randomBytes = random_bytes(24); // Reduced to 24 bytes to leave room for timestamp
-        $emailHash = hash('sha256', $email, true);
-        $tokenData = $emailHash . $randomBytes;
-        $uniqueToken = bin2hex($tokenData);
-        
-        // Add timestamp
-        $timestamp = time();
-        $token = $uniqueToken . '.' . $timestamp;
-        
-        // Ensure token length is within 255 character limit
-        if (strlen($token) > 255) {
-            // If too long, truncate the unique part but keep the timestamp
-            $maxUniqueLength = 255 - strlen('.' . $timestamp);
-            $uniqueToken = substr($uniqueToken, 0, $maxUniqueLength);
-            $token = $uniqueToken . '.' . $timestamp;
-        }
-        
-        return $token;
-    }
-    
-    /**
-     * Validate token format, expiration, and match with stored token
-     * 
-     * @param string $providedToken Token from the reset request
-     * @param object $user User object with stored password/token
-     * @return bool True if token is valid and not expired
-     */
-    private function isValidToken($providedToken, $user) {
-        // Check if stored token exists
-        if (empty($user->password)) {
-            return false;
-        }
-        
-        // Check if provided token matches stored token
-        if ($user->password !== $providedToken) {
-            return false;
-        }
-        
-        // Extract timestamp from token
-        $tokenParts = explode('.', $providedToken);
-        if (count($tokenParts) !== 2) {
-            return false; // Invalid token format
-        }
-        
-        $timestamp = (int)$tokenParts[1];
-        $currentTime = time();
-        $tokenAge = $currentTime - $timestamp;
-        
-        // Check if token is expired (1 hour = 3600 seconds)
-        if ($tokenAge > 3600) {
-            return false;
-        }
-        
-        return true;
-    }
-
-    /**
-     * Generate HTML email body for password reset
-     * 
-     * @param object $user User object with email and name properties
-     * @param string $token Password reset token
-     * @return string HTML email content
-     */
-    private function generatePasswordResetEmailHtml($user, $token) {
-        $userName = htmlspecialchars($user->name ?: 'there');
-        $userEmail = htmlspecialchars($user->email);
-        $resetUrl = SHIPYARD_URL . '/password.html?token=' . urlencode($token);
-        $resetUrlDisplay = htmlspecialchars($resetUrl);
-
-        return '<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Kyte Shipyard - Password Reset</title>
-    <style>
-        body {
-            font-family: -apple-system, BlinkMacSystemFont, \'Segoe UI\', Roboto, Helvetica, Arial, sans-serif;
-            line-height: 1.6;
-            color: #333;
-            max-width: 600px;
-            margin: 0 auto;
-            padding: 20px;
-            background-color: #f8f9fa;
-        }
-        .email-container {
-            background-color: white;
-            border-radius: 8px;
-            padding: 40px;
-            box-shadow: 0 2px 10px rgba(0,0,0,0.1);
-        }
-        .header {
-            text-align: center;
-            margin-bottom: 30px;
-        }
-        .logo {
-            font-size: 28px;
-            font-weight: bold;
-            color: #2563eb;
-            margin-bottom: 10px;
-        }
-        .subtitle {
-            color: #6b7280;
-            font-size: 16px;
-        }
-        .content {
-            margin-bottom: 30px;
-        }
-        .greeting {
-            font-size: 18px;
-            margin-bottom: 20px;
-            color: #1f2937;
-        }
-        .message {
-            margin-bottom: 25px;
-            color: #4b5563;
-            line-height: 1.7;
-        }
-        .reset-button {
-            display: inline-block;
-            background-color: #2563eb;
-            color: white;
-            padding: 14px 30px;
-            text-decoration: none;
-            border-radius: 6px;
-            font-weight: 600;
-            font-size: 16px;
-            margin: 20px 0;
-            transition: background-color 0.3s ease;
-        }
-        .reset-button:hover {
-            background-color: #1d4ed8;
-        }
-        .button-container {
-            text-align: center;
-            margin: 30px 0;
-        }
-        .alternative-link {
-            background-color: #f3f4f6;
-            border: 1px solid #d1d5db;
-            border-radius: 4px;
-            padding: 12px;
-            font-family: monospace;
-            font-size: 14px;
-            word-break: break-all;
-            color: #374151;
-            margin: 15px 0;
-        }
-        .security-notice {
-            background-color: #fef3c7;
-            border-left: 4px solid #f59e0b;
-            padding: 15px;
-            margin: 25px 0;
-            border-radius: 4px;
-        }
-        .security-notice h4 {
-            margin: 0 0 8px 0;
-            color: #92400e;
-            font-size: 16px;
-        }
-        .security-notice p {
-            margin: 0;
-            color: #78350f;
-            font-size: 14px;
-        }
-        .footer {
-            margin-top: 40px;
-            padding-top: 20px;
-            border-top: 1px solid #e5e7eb;
-            text-align: center;
-            color: #6b7280;
-            font-size: 14px;
-        }
-        .footer p {
-            margin: 5px 0;
-        }
-        @media (max-width: 600px) {
-            body {
-                padding: 10px;
-            }
-            .email-container {
-                padding: 20px;
-            }
-            .reset-button {
-                display: block;
-                text-align: center;
-                width: 100%;
-                box-sizing: border-box;
-            }
-        }
-    </style>
-</head>
-<body>
-    <div class="email-container">
-        <div class="header">
-            <div class="logo">⚓ Kyte Shipyard</div>
-            <div class="subtitle">Password Reset Request</div>
-        </div>
-        
-        <div class="content">
-            <div class="greeting">
-                Hello ' . $userName . ',
-            </div>
-            
-            <div class="message">
-                We received a request to reset the password for your Kyte Shipyard account associated with <strong>' . $userEmail . '</strong>.
-            </div>
-            
-            <div class="message">
-                Click the button below to reset your password. This link will expire in 1 hour for your security.
-            </div>
-            
-            <div class="button-container">
-                <a href="' . $resetUrl . '" class="reset-button">
-                    Reset My Password
-                </a>
-            </div>
-            
-            <div class="message">
-                If the button above doesn\'t work, you can copy and paste this link into your browser:
-            </div>
-            
-            <div class="alternative-link">
-                ' . $resetUrlDisplay . '
-            </div>
-            
-            <div class="security-notice">
-                <h4>🔒 Security Notice</h4>
-                <p>If you didn\'t request this password reset, please ignore this email. For security reasons, this reset link will expire in 1 hour and you will need to generate a new request if it expires.</p>
-            </div>
-        </div>
-        
-        <div class="footer">
-            <p><strong>Kyte Shipyard Team</strong></p>
-            <p>This is an automated message, please do not reply to this email.</p>
-            <p style="margin-top: 15px; font-size: 12px; color: #9ca3af;">
-                If you\'re having trouble with the reset process, please contact our support team.
-            </p>
-        </div>
-    </div>
-</body>
-</html>';
     }
 }

--- a/src/Mvc/Controller/ModelController.php
+++ b/src/Mvc/Controller/ModelController.php
@@ -191,7 +191,17 @@ class ModelController
         $this->shipyard_init();
 
         $this->hook_init();
-        
+
+        // Anonymous app-context (JWT-mode public access via AppContextStrategy)
+        // is READ-ONLY: no user is resolved, so restrict to GET regardless of
+        // the controller's allowableActions. Writes require an authenticated
+        // user/session. Only fires in dispatcher mode when the anonymous
+        // strategy was selected; every other path is unaffected.
+        if (isset($this->api->authStrategy) && $this->api->authStrategy !== null
+            && $this->api->authStrategy->name() === 'app_context') {
+            $this->allowableActions = array_values(array_intersect($this->allowableActions, ['get']));
+        }
+
         if ($this->requireAuth && !$this->internal) {
             $this->authenticate();
         }

--- a/src/Mvc/Controller/ModelController.php
+++ b/src/Mvc/Controller/ModelController.php
@@ -194,16 +194,25 @@ class ModelController
 
         // Anonymous app-context (JWT-mode public access via AppContextStrategy).
         // Per-app tri-state Application.allow_public governs the anonymous
-        // surface: 1 = read-only (restrict to GET regardless of the
-        // controller's allowableActions); 2 = controller-governed (the
-        // controller's own requireAuth=false + allowableActions declaration
-        // applies, including writes — the same contract HMAC anonymous has
-        // always honored). allow_public=0 never reaches here (preAuth rejects).
-        // Only fires in dispatcher mode when the anonymous strategy was
-        // selected; every other path is unaffected.
+        // surface: 1 = read-only (GET only, regardless of the controller's
+        // allowableActions); 2 = controller-governed (the controller's own
+        // requireAuth=false + allowableActions declaration applies, including
+        // writes — the same contract HMAC anonymous has always honored).
+        // allow_public=0 never reaches here (preAuth rejects). Only fires in
+        // dispatcher mode when the anonymous strategy was selected; every
+        // other path is unaffected.
+        //
+        // Read-only is enforced on the HTTP METHOD, not just allowableActions:
+        // controllers that override new()/update()/delete() (e.g.
+        // KytePasswordResetController) skip the base class's allowableActions
+        // check, so the intersect alone is bypassable. Throwing here runs
+        // before any action method can.
         if (isset($this->api->authStrategy) && $this->api->authStrategy !== null
             && $this->api->authStrategy->name() === 'app_context'
             && (int)($this->api->app->allow_public ?? 0) === 1) {
+            if (strtoupper((string)$this->api->request) !== 'GET') {
+                throw new \Kyte\Exception\SessionException("Anonymous access to this application is read-only.");
+            }
             $this->allowableActions = array_values(array_intersect($this->allowableActions, ['get']));
         }
 

--- a/src/Mvc/Controller/ModelController.php
+++ b/src/Mvc/Controller/ModelController.php
@@ -192,13 +192,18 @@ class ModelController
 
         $this->hook_init();
 
-        // Anonymous app-context (JWT-mode public access via AppContextStrategy)
-        // is READ-ONLY: no user is resolved, so restrict to GET regardless of
-        // the controller's allowableActions. Writes require an authenticated
-        // user/session. Only fires in dispatcher mode when the anonymous
-        // strategy was selected; every other path is unaffected.
+        // Anonymous app-context (JWT-mode public access via AppContextStrategy).
+        // Per-app tri-state Application.allow_public governs the anonymous
+        // surface: 1 = read-only (restrict to GET regardless of the
+        // controller's allowableActions); 2 = controller-governed (the
+        // controller's own requireAuth=false + allowableActions declaration
+        // applies, including writes — the same contract HMAC anonymous has
+        // always honored). allow_public=0 never reaches here (preAuth rejects).
+        // Only fires in dispatcher mode when the anonymous strategy was
+        // selected; every other path is unaffected.
         if (isset($this->api->authStrategy) && $this->api->authStrategy !== null
-            && $this->api->authStrategy->name() === 'app_context') {
+            && $this->api->authStrategy->name() === 'app_context'
+            && (int)($this->api->app->allow_public ?? 0) === 1) {
             $this->allowableActions = array_values(array_intersect($this->allowableActions, ['get']));
         }
 

--- a/src/Mvc/Model/Application.php
+++ b/src/Mvc/Model/Application.php
@@ -182,9 +182,14 @@ $Application = [
 		],
 
 		// Per-app opt-in for anonymous/public API access (AppContextStrategy,
-		// JWT-mode public access). 0 = anonymous appid-only requests rejected
-		// (default); 1 = requireAuth=false controllers are reachable
-		// anonymously (read-only). See src/Core/Auth/AppContextStrategy.php.
+		// JWT-mode public access). Tri-state:
+		//   0 = anonymous appid-only requests rejected (default);
+		//   1 = requireAuth=false controllers reachable anonymously, READ-ONLY
+		//       (GET only — public catalog/storefront browsing);
+		//   2 = controller-governed — the controller's requireAuth=false +
+		//       allowableActions declaration applies, including writes
+		//       (password reset / signup-style public flows).
+		// See src/Core/Auth/AppContextStrategy.php.
 		'allow_public'	=> [
 			'type'		=> 'i',
 			'required'	=> false,

--- a/src/Mvc/Model/Application.php
+++ b/src/Mvc/Model/Application.php
@@ -181,6 +181,19 @@ $Application = [
 			'default'	=> 'hmac',
 		],
 
+		// Per-app opt-in for anonymous/public API access (AppContextStrategy,
+		// JWT-mode public access). 0 = anonymous appid-only requests rejected
+		// (default); 1 = requireAuth=false controllers are reachable
+		// anonymously (read-only). See src/Core/Auth/AppContextStrategy.php.
+		'allow_public'	=> [
+			'type'		=> 'i',
+			'required'	=> false,
+			'size'		=> 1,
+			'unsigned'	=> true,
+			'default'	=> 0,
+			'date'		=> false,
+		],
+
 		// framework attributes
 
 		'kyte_account'	=> [

--- a/tests/AppContextStrategyTest.php
+++ b/tests/AppContextStrategyTest.php
@@ -129,6 +129,39 @@ class AppContextStrategyTest extends TestCase
         (new AppContextStrategy())->preAuth($api);
     }
 
+    public function testPreAuthAcceptsControllerGovernedMode(): void
+    {
+        // allow_public = 2 (controller-governed) must pass preAuth with the
+        // same anonymous invariant as read-only mode — the read-only vs
+        // controller-governed distinction is enforced in ModelController.
+        $api = $this->makeApi();
+        $acct = new \Kyte\Core\ModelObject(KyteAccount);
+        $acct->create(['number' => 'appctx-' . uniqid(), 'name' => 'AppCtx Test']);
+        $app = $this->makeApp((int)$acct->id, 2);
+        $api->app = $app;
+        $api->appId = $app->identifier;
+
+        (new AppContextStrategy())->preAuth($api);
+
+        $this->assertSame((int)$acct->id, (int)$api->account->id, 'account resolved from the app');
+        $this->assertNull($api->user, 'no user is resolved (anonymous)');
+        $this->assertFalse($api->session->hasSession, 'hasSession is never set — the security invariant');
+    }
+
+    public function testPreAuthRejectsUnknownAllowPublicValue(): void
+    {
+        // Only 1 and 2 are valid opt-ins; anything else is treated as off.
+        $api = $this->makeApi();
+        $acct = new \Kyte\Core\ModelObject(KyteAccount);
+        $acct->create(['number' => 'appctx-' . uniqid(), 'name' => 'AppCtx Test']);
+        $app = $this->makeApp((int)$acct->id, 3);
+        $api->app = $app;
+        $api->appId = $app->identifier;
+
+        $this->expectException(SessionException::class);
+        (new AppContextStrategy())->preAuth($api);
+    }
+
     public function testPreAuthRejectsWithoutApp(): void
     {
         $api = $this->makeApi();

--- a/tests/AppContextStrategyTest.php
+++ b/tests/AppContextStrategyTest.php
@@ -1,0 +1,141 @@
+<?php
+namespace Kyte\Test;
+
+use Kyte\Core\Api;
+use Kyte\Core\Auth\AppContextStrategy;
+use Kyte\Exception\SessionException;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Coverage for AppContextStrategy (JWT-mode anonymous/public access).
+ *
+ * matches() is a pure header truth-table. preAuth() must resolve the account
+ * from the app but NEVER resolve a user or set hasSession (the security
+ * invariant that keeps requireAuth=true controllers at 403), and must enforce
+ * the per-app allow_public opt-in.
+ */
+class AppContextStrategyTest extends TestCase
+{
+    private function clearAuthHeaders(): void
+    {
+        unset(
+            $_SERVER['HTTP_X_KYTE_APPID'],
+            $_SERVER['HTTP_AUTHORIZATION'],
+            $_SERVER['REDIRECT_HTTP_AUTHORIZATION'],
+            $_SERVER['HTTP_X_KYTE_SIGNATURE'],
+            $_SERVER['HTTP_X_KYTE_IDENTITY']
+        );
+    }
+
+    protected function setUp(): void
+    {
+        $this->clearAuthHeaders();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->clearAuthHeaders();
+    }
+
+    // ---------- matches() truth table ----------
+
+    public function testMatchesWhenOnlyAppidPresent(): void
+    {
+        $_SERVER['HTTP_X_KYTE_APPID'] = 'appctx-id';
+        $this->assertTrue((new AppContextStrategy())->matches());
+    }
+
+    public function testNoMatchWithoutAppid(): void
+    {
+        $this->assertFalse((new AppContextStrategy())->matches());
+    }
+
+    public function testNoMatchWithBearer(): void
+    {
+        $_SERVER['HTTP_X_KYTE_APPID'] = 'appctx-id';
+        $_SERVER['HTTP_AUTHORIZATION'] = 'Bearer eyJhbGciOiJIUzI1NiJ9.e30.sig';
+        $this->assertFalse((new AppContextStrategy())->matches(), 'must not shadow a Bearer (JWT/MCP)');
+    }
+
+    public function testNoMatchWithSignature(): void
+    {
+        $_SERVER['HTTP_X_KYTE_APPID'] = 'appctx-id';
+        $_SERVER['HTTP_X_KYTE_SIGNATURE'] = 'deadbeef';
+        $this->assertFalse((new AppContextStrategy())->matches(), 'must not shadow signed HMAC');
+    }
+
+    public function testNoMatchWithIdentity(): void
+    {
+        $_SERVER['HTTP_X_KYTE_APPID'] = 'appctx-id';
+        $_SERVER['HTTP_X_KYTE_IDENTITY'] = 'c29tZS1pZGVudGl0eQ==';
+        $this->assertFalse((new AppContextStrategy())->matches(), 'must not shadow HMAC identity');
+    }
+
+    // ---------- preAuth() ----------
+
+    private function makeApi(): Api
+    {
+        \Kyte\Core\DBI::dbInit(KYTE_DB_USERNAME, KYTE_DB_PASSWORD, KYTE_DB_HOST, KYTE_DB_DATABASE, KYTE_DB_CHARSET, 'InnoDB');
+        $api = new Api();
+        \Kyte\Core\DBI::createTable(KyteAccount);
+        \Kyte\Core\DBI::createTable(Application);
+        $api->response = [];
+        $api->user = null;
+        $api->session = new \stdClass();
+        $api->session->hasSession = false;
+        return $api;
+    }
+
+    private function makeApp(int $accountId, int $allowPublic): \Kyte\Core\ModelObject
+    {
+        $app = new \Kyte\Core\ModelObject(Application);
+        $app->create([
+            'name'         => 'AppCtx Test App',
+            'identifier'   => 'appctx-' . uniqid(),
+            'allow_public' => $allowPublic,
+            'kyte_account' => $accountId,
+        ]);
+        return $app;
+    }
+
+    public function testPreAuthResolvesAccountButNoUserOrSession(): void
+    {
+        $api = $this->makeApi();
+        $acct = new \Kyte\Core\ModelObject(KyteAccount);
+        $acct->create(['number' => 'appctx-' . uniqid(), 'name' => 'AppCtx Test']);
+        $app = $this->makeApp((int)$acct->id, 1);
+        $api->app = $app;
+        $api->appId = $app->identifier;
+
+        (new AppContextStrategy())->preAuth($api);
+
+        $this->assertSame((int)$acct->id, (int)$api->account->id, 'account resolved from the app');
+        $this->assertNull($api->user, 'no user is resolved (anonymous)');
+        $this->assertFalse($api->session->hasSession, 'hasSession is never set — the security invariant');
+        $this->assertSame('0', $api->response['session']);
+        $this->assertSame('0', $api->response['uid']);
+    }
+
+    public function testPreAuthRejectsWhenNotOptedIn(): void
+    {
+        $api = $this->makeApi();
+        $acct = new \Kyte\Core\ModelObject(KyteAccount);
+        $acct->create(['number' => 'appctx-' . uniqid(), 'name' => 'AppCtx Test']);
+        $app = $this->makeApp((int)$acct->id, 0); // allow_public = 0
+        $api->app = $app;
+        $api->appId = $app->identifier;
+
+        $this->expectException(SessionException::class);
+        (new AppContextStrategy())->preAuth($api);
+    }
+
+    public function testPreAuthRejectsWithoutApp(): void
+    {
+        $api = $this->makeApi();
+        $api->app = null;
+        $api->appId = null;
+
+        $this->expectException(SessionException::class);
+        (new AppContextStrategy())->preAuth($api);
+    }
+}

--- a/tests/JwtEndpointTest.php
+++ b/tests/JwtEndpointTest.php
@@ -27,6 +27,10 @@ use PHPUnit\Framework\TestCase;
  *                 missing body → 400
  *   /jwt/logout   valid → 200 + token revoked; second call idempotent
  *   /jwt/logout-all valid → 200 + all user tokens revoked across families
+ *   /jwt/password-* reset: no-reveal (unknown email also 200), token stored
+ *                 raw + login disabled while pending; validate: live/consumed;
+ *                 update: sets hashed password + revokes refresh families,
+ *                 expired/unknown token → 401 (KYTE-#268)
  *   Routing       Unknown action → 404
  *                 GET method → 405
  */
@@ -296,6 +300,146 @@ class JwtEndpointTest extends TestCase
         $rows = \Kyte\Core\DBI::query("SELECT token_family FROM `KyteRefreshToken` WHERE token_hash = '$hash'");
         $this->assertNotEmpty($rows);
         return (string)$rows[0]['token_family'];
+    }
+
+    // ---------- /jwt/password-* (KYTE-#268) ----------
+
+    public function testPasswordResetMissingEmailReturns400(): void
+    {
+        $result = JwtEndpoint::process($this->api, $this->serverFor('/jwt/password-reset'), $this->jsonBody([]));
+
+        $this->assertSame(400, $result['status']);
+        $this->assertSame('invalid_request', $result['body']['error']);
+    }
+
+    public function testPasswordResetUnknownEmailStillReturnsOk(): void
+    {
+        // No-reveal: unknown email gets the same response as a known one.
+        $result = JwtEndpoint::process($this->api, $this->serverFor('/jwt/password-reset'), $this->jsonBody([
+            'email' => 'jwt-endpoint-nobody@example.com',
+        ]));
+
+        $this->assertSame(200, $result['status']);
+        $this->assertTrue($result['body']['ok']);
+    }
+
+    public function testPasswordResetKnownEmailStoresTokenAndDisablesLogin(): void
+    {
+        $result = JwtEndpoint::process($this->api, $this->serverFor('/jwt/password-reset'), $this->jsonBody([
+            'email' => $this->userEmail,
+        ]));
+
+        $this->assertSame(200, $result['status']);
+        $this->assertTrue($result['body']['ok']);
+
+        // The raw token replaced the password hash: hex.unixtime format.
+        $user = new \Kyte\Core\ModelObject(KyteUser);
+        $this->assertTrue($user->retrieve('id', $this->userId));
+        $this->assertMatchesRegularExpression('/^[0-9a-f]+\.\d+$/', (string)$user->password);
+
+        // Login with the old password is disabled while the reset is pending
+        // (password_verify can never match a raw token).
+        $login = JwtEndpoint::process($this->api, $this->serverFor('/jwt/login'), $this->jsonBody([
+            'email'    => $this->userEmail,
+            'password' => self::PASSWORD,
+        ]));
+        $this->assertSame(401, $login['status']);
+    }
+
+    public function testPasswordValidateAndUpdateFlow(): void
+    {
+        // Seed a valid reset token directly (skips the SES email step).
+        $token = \Kyte\Core\Auth\PasswordResetFlow::generateToken($this->userEmail);
+        $user = new \Kyte\Core\ModelObject(KyteUser);
+        $this->assertTrue($user->retrieve('id', $this->userId));
+        $user->save(['password' => $token]);
+
+        // Validate — token is live.
+        $validate = JwtEndpoint::process($this->api, $this->serverFor('/jwt/password-validate'), $this->jsonBody([
+            'token' => $token,
+        ]));
+        $this->assertSame(200, $validate['status']);
+        $this->assertTrue($validate['body']['valid']);
+
+        // Update — sets the new password (hashed).
+        $newPassword = 'jwt-endpoint-new-password-4821';
+        $update = JwtEndpoint::process($this->api, $this->serverFor('/jwt/password-update'), $this->jsonBody([
+            'token'    => $token,
+            'password' => $newPassword,
+        ]));
+        $this->assertSame(200, $update['status']);
+        $this->assertTrue($update['body']['ok']);
+
+        // Token is consumed — validate now reports invalid.
+        $revalidate = JwtEndpoint::process($this->api, $this->serverFor('/jwt/password-validate'), $this->jsonBody([
+            'token' => $token,
+        ]));
+        $this->assertSame(200, $revalidate['status']);
+        $this->assertFalse($revalidate['body']['valid']);
+
+        // Login with the NEW password works.
+        $login = JwtEndpoint::process($this->api, $this->serverFor('/jwt/login'), $this->jsonBody([
+            'email'    => $this->userEmail,
+            'password' => $newPassword,
+        ]));
+        $this->assertSame(200, $login['status']);
+        $this->assertArrayHasKey('access_token', $login['body']);
+    }
+
+    public function testPasswordUpdateRevokesRefreshTokenFamilies(): void
+    {
+        // Establish a session first, then reset the password — the old
+        // refresh token must be revoked.
+        $login = JwtEndpoint::process($this->api, $this->serverFor('/jwt/login'), $this->jsonBody([
+            'email'    => $this->userEmail,
+            'password' => self::PASSWORD,
+        ]));
+        $this->assertSame(200, $login['status']);
+        $refreshToken = $login['body']['refresh_token'];
+
+        $token = \Kyte\Core\Auth\PasswordResetFlow::generateToken($this->userEmail);
+        $user = new \Kyte\Core\ModelObject(KyteUser);
+        $this->assertTrue($user->retrieve('id', $this->userId));
+        $user->save(['password' => $token]);
+
+        $update = JwtEndpoint::process($this->api, $this->serverFor('/jwt/password-update'), $this->jsonBody([
+            'token'    => $token,
+            'password' => 'jwt-endpoint-after-revoke-7733',
+        ]));
+        $this->assertSame(200, $update['status']);
+
+        $refresh = JwtEndpoint::process($this->api, $this->serverFor('/jwt/refresh'), $this->jsonBody([
+            'refresh_token' => $refreshToken,
+        ]));
+        $this->assertSame(401, $refresh['status']);
+    }
+
+    public function testPasswordUpdateWithExpiredTokenReturns401(): void
+    {
+        // Hand-craft a token whose timestamp is 2 hours old.
+        $expired = bin2hex(random_bytes(32)) . '.' . (time() - 7200);
+        $user = new \Kyte\Core\ModelObject(KyteUser);
+        $this->assertTrue($user->retrieve('id', $this->userId));
+        $user->save(['password' => $expired]);
+
+        $result = JwtEndpoint::process($this->api, $this->serverFor('/jwt/password-update'), $this->jsonBody([
+            'token'    => $expired,
+            'password' => 'whatever-5912',
+        ]));
+
+        $this->assertSame(401, $result['status']);
+        $this->assertSame('invalid_token', $result['body']['error']);
+    }
+
+    public function testPasswordUpdateWithUnknownTokenReturns401(): void
+    {
+        $result = JwtEndpoint::process($this->api, $this->serverFor('/jwt/password-update'), $this->jsonBody([
+            'token'    => bin2hex(random_bytes(32)) . '.' . time(),
+            'password' => 'whatever-3317',
+        ]));
+
+        $this->assertSame(401, $result['status']);
+        $this->assertSame('invalid_token', $result['body']['error']);
     }
 
     private function serverFor(string $path): array

--- a/tests/JwtEndpointTest.php
+++ b/tests/JwtEndpointTest.php
@@ -360,6 +360,7 @@ class JwtEndpointTest extends TestCase
         ]));
         $this->assertSame(200, $validate['status']);
         $this->assertTrue($validate['body']['valid']);
+        $this->assertSame($this->userEmail, $validate['body']['email']);
 
         // Update — sets the new password (hashed).
         $newPassword = 'jwt-endpoint-new-password-4821';


### PR DESCRIPTION
Server-side half of #229: lets JWT-mode sites serve requireAuth=false controllers to anonymous visitors via x-kyte-appid only. New AppContextStrategy (strict matches, account-only/no-user/no-hasSession), per-app opt-in + migration, shadow-harness skip, tests. kyte-api-js anonymous fall-through (kyte-api-js #37) ships alongside.

**Tri-state `Application.allow_public`** (folded in after design review — read-only-only broke pre-login write flows like password reset, whose `new`/`update` are POST/PUT):
- `0` off (default) — anonymous rejected in preAuth
- `1` read-only — GET only, enforced on the **HTTP method** in `ModelController::init()` (controllers that override action methods skip the base `allowableActions` check, so the intersect alone was bypassable — caught in dev QA)
- `2` controller-governed — the controller's `requireAuth=false` + `allowableActions` govern, incl. writes. Same contract HMAC anonymous has always honored (the signing endpoint mints anonymous signatures from the embedded public key alone), so `2` exposes nothing HMAC does not.

The no-user/no-hasSession invariant is independent of the mode: `requireAuth=true` controllers 403 in every mode.

**Dev QA (device 19, real HTTP, branch deployed via composer):** mode 0 → 403 not-enabled; mode 1 → GET 200 / POST 403 / PUT 403; mode 2 → POST (password reset, nonexistent email) 200 / requireAuth=true GET 403; appid+identity → HMAC's error, appid+Bearer → JWT's error (no shadowing).

**Known scope limit:** Shipyard itself is platform-level (`applicationId` null — no `x-kyte-appid`), so Shipyard's own password reset is NOT served by this path; that's a separate platform-level follow-up (JwtEndpoint-style dedicated routes). This PR covers app-scoped public sites (storefronts/catalogs and app-scoped pre-login flows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)