### PR TITLE
KYTE-#201: v4.12.0 — remove KYTE_USE_SNS, Shipyard update → cron worker, per-app DB SSL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,28 @@ Direct CloudFront invalidation (shipped + verified in 4.11.1) is now the only pa
 
 - Dropped the `if (KYTE_USE_SNS) { <SNS publish> } else { <direct> }` fork at all 10 sites, keeping only the direct `Kyte\Aws\CloudFront::createInvalidation()` call inside its existing best-effort try/catch: `ApplicationController` (republish-all), `KytePageController` ×3, `KyteScriptController` ×2 (`invalidateCloudFront`/`invalidateCloudFrontForDeletion`), `KyteLibraryController` ×2, `KytePageDataController`, `NavigationController`, `SideNavController`.
 - Removed `'KYTE_USE_SNS' => false` from `Api::$defaultEnvironmentConstants` and the `define('KYTE_USE_SNS', ...)` from `sample-config.php` + docs.
-- **Kept** `SNS_REGION`, `SNS_QUEUE_SITE_MANAGEMENT`, `SNS_KYTE_SHIPYARD_UPDATE` and the `Kyte\Aws\Sns` class — still used by site-provisioning and shipyard-update (migrated in later #201 work). Updated the PHPStan baseline accordingly.
+- **Kept** `SNS_REGION`, `SNS_QUEUE_SITE_MANAGEMENT` and the `Kyte\Aws\Sns` class — still used by site-provisioning (migrated in later #201 work). Updated the PHPStan baseline accordingly. (`SNS_KYTE_SHIPYARD_UPDATE` is no longer referenced after the shipyard-update migration below.)
 
 ### Fix: per-app DB connections (`DBI::connectApp()`) now use SSL when `KYTE_DB_CA_BUNDLE` is set
 
 `DBI::connectApp()` — the per-application/tenant connection used by `Api::dbappconnect()` — opened a plain `mysqli` connection with **no TLS**, unlike `DBI::connect()`. Against a database with `require_secure_transport=ON` this fails with *"Connections using insecure transport are prohibited"*: the control-plane connection (already SSL) succeeds so **login works**, but opening any application backed by a **dedicated per-app database** fails. Latent until a deployment runs on an SSL-required server — surfaced migrating the dev server from Aurora (`require_secure_transport=OFF`) to a MariaDB RDS with it `ON`.
 
 - `connectApp()` now mirrors `connect()`: when `KYTE_DB_CA_BUNDLE` is defined it connects via `ssl_set()` + `MYSQLI_CLIENT_SSL`, with the same non-SSL fallback on failure. **Gated on the constant**, so deployments that don't define a CA bundle keep identical non-SSL behavior (no-op) — verified against ORB/ORT and ETOM, which are unaffected.
-- Fixed a dead-code bug in `DBI::dbInitApp()`: it referenced non-existent `setCharsetApp()`/`setEngineApp()` (fatal if ever invoked) and returned `connect()` instead of `connectApp()`. No callers today (live path is `Api::dbappconnect()`), so behavior-neutral.
+- Fixed the `Api::dbappconnect()` per-app routing guard: it compared the **main** connection's statics (`$dbUser`/`$dbName`/`$dbHost`) instead of the **app** statics (`$dbUserApp`/`$dbNameApp`/`$dbHostApp`), so the "already connected to this app" short-circuit never fired. Corrected the comparison **and** added `DBI::closeApp()` when the app target changes, so in-process app switching reconnects to the right tenant DB instead of reusing the previous app's cached handle. Latent cross-tenant hazard, previously masked by single-app-per-request + the cron worker's fork/`reconnect()` (which clears the app handle).
+- Removed dead method `DBI::dbInitApp()` — it could never run (called non-existent `setCharsetApp()`/`setEngineApp()`), had no callers anywhere, and duplicated the live `Api::dbappconnect()` path.
+
+### Migration: Shipyard self-update moved from Lambda into a kyte-php cron worker — KYTE-#201
+
+`KyteShipyardUpdateController::new` previously published `current_version` to `SNS_KYTE_SHIPYARD_UPDATE` and the `kyte-lambda-update-shipyard` Lambda did the work. That Lambda had two production bugs: `mimetypes.guess_type()` returned `None` for `.map`/directory entries → `boto3 upload_file(ContentType=None)` **failed** (source maps never uploaded), and its `kyte_shipyard_cf` env var pointed at a **nonexistent distribution** → the invalidation threw `NoSuchDistribution` and the dashboard served stale.
+
+The update now runs **out-of-band in a cron worker**, not synchronously in the request. The download/extract/upload/invalidate routinely exceeds the **~100s Cloudflare non-enterprise** request ceiling (and ALB idle timeouts), so a synchronous controller action would 524 on Cloudflare-fronted installs. Both Lambda bugs are fixed inherently.
+
+- **New `KyteShipyardUpdate` model + table** (`migrations/4.12.0_shipyard_update.sql`) tracks each request and its outcome (`status` pending→running→complete/failed, `requested_version`, `deployed_version`, `files_uploaded`/`files_failed`, `cloudfront_invalidated`, `message`).
+- **`KyteShipyardUpdateController::new`** does a fast inline CDN version check (~100ms) and returns "up to date" immediately when current; otherwise it enqueues a `KyteShipyardUpdate` row (`status=pending`) and returns it. The dashboard polls `GET` on the model by id for live status.
+- **`ShipyardUpdateWorker`** (`src/Cron/ShipyardUpdateWorker.php`, a `CronJobBase` job, interval 60s) claims the oldest pending row, downloads + extracts the stable `kyte-shipyard.zip` (ext-zip / `ZipArchive`), uploads every file via `Kyte\Aws\S3::write()` with an **explicit per-extension Content-Type** (JS→`application/javascript`, CSS→`text/css`; unknown types like `.map` are omitted rather than crashing — fixes bug #1), then invalidates the distribution from **config** `KYTE_SHIPYARD_CF` (fixes bug #2, best-effort). `heartbeat()` extends the lease during large uploads.
+- **Idempotency, two layers:** the controller refuses to enqueue while a row is pending/running (request dedup); the worker registers with `allow_concurrent=0` (lease lock) and claims rows via a guarded `pending→running` UPDATE keyed on `affected_rows()==1` (execution dedup).
+
+**Setup:** run the migration, `php bin/register-shipyard-update-job.php`, and set `KYTE_SHIPYARD_S3` / `KYTE_SHIPYARD_CF` (+ optional `KYTE_SHIPYARD_REGION`, default `us-east-1`) in `config.php`. **New dependency:** `ext-zip`. `SNS_KYTE_SHIPYARD_UPDATE` is no longer referenced (the Lambda + SNS topic are decommissioned in the final #201 step).
 
 ## 4.11.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+## 4.12.0
+
+### Cleanup: remove `KYTE_USE_SNS` flag + dead SNS invalidation branches — KYTE-#201
+
+Direct CloudFront invalidation (shipped + verified in 4.11.1) is now the only path. With every install already running `KYTE_USE_SNS=false`, this removes the flag and the now-dead SNS publish branch at every invalidation site — behavior-neutral cleanup.
+
+- Dropped the `if (KYTE_USE_SNS) { <SNS publish> } else { <direct> }` fork at all 10 sites, keeping only the direct `Kyte\Aws\CloudFront::createInvalidation()` call inside its existing best-effort try/catch: `ApplicationController` (republish-all), `KytePageController` ×3, `KyteScriptController` ×2 (`invalidateCloudFront`/`invalidateCloudFrontForDeletion`), `KyteLibraryController` ×2, `KytePageDataController`, `NavigationController`, `SideNavController`.
+- Removed `'KYTE_USE_SNS' => false` from `Api::$defaultEnvironmentConstants` and the `define('KYTE_USE_SNS', ...)` from `sample-config.php` + docs.
+- **Kept** `SNS_REGION`, `SNS_QUEUE_SITE_MANAGEMENT`, `SNS_KYTE_SHIPYARD_UPDATE` and the `Kyte\Aws\Sns` class — still used by site-provisioning and shipyard-update (migrated in later #201 work). Updated the PHPStan baseline accordingly.
+
+### Fix: per-app DB connections (`DBI::connectApp()`) now use SSL when `KYTE_DB_CA_BUNDLE` is set
+
+`DBI::connectApp()` — the per-application/tenant connection used by `Api::dbappconnect()` — opened a plain `mysqli` connection with **no TLS**, unlike `DBI::connect()`. Against a database with `require_secure_transport=ON` this fails with *"Connections using insecure transport are prohibited"*: the control-plane connection (already SSL) succeeds so **login works**, but opening any application backed by a **dedicated per-app database** fails. Latent until a deployment runs on an SSL-required server — surfaced migrating the dev server from Aurora (`require_secure_transport=OFF`) to a MariaDB RDS with it `ON`.
+
+- `connectApp()` now mirrors `connect()`: when `KYTE_DB_CA_BUNDLE` is defined it connects via `ssl_set()` + `MYSQLI_CLIENT_SSL`, with the same non-SSL fallback on failure. **Gated on the constant**, so deployments that don't define a CA bundle keep identical non-SSL behavior (no-op) — verified against ORB/ORT and ETOM, which are unaffected.
+- Fixed a dead-code bug in `DBI::dbInitApp()`: it referenced non-existent `setCharsetApp()`/`setEngineApp()` (fatal if ever invoked) and returned `connect()` instead of `connectApp()`. No callers today (live path is `Api::dbappconnect()`), so behavior-neutral.
+
 ## 4.11.1
 
 ### Fix: CloudFront invalidation `CallerReference` collision (direct/`KYTE_USE_SNS=false` path) — KYTE-#201

--- a/bin/register-shipyard-update-job.php
+++ b/bin/register-shipyard-update-job.php
@@ -1,0 +1,111 @@
+#!/usr/bin/env php
+<?php
+/**
+ * Register Shipyard Update Cron Job
+ *
+ * Registers ShipyardUpdateWorker in the CronJob table so the cron worker daemon
+ * drains pending KyteShipyardUpdate requests (KYTE-#201). The dashboard enqueues
+ * a request; this job performs the download/extract/upload/CloudFront-invalidate
+ * out-of-band (off the Cloudflare/ALB request path).
+ *
+ * Prereqs:
+ *   - Run migrations/4.12.0_shipyard_update.sql (creates KyteShipyardUpdate).
+ *   - Define KYTE_SHIPYARD_S3 and KYTE_SHIPYARD_CF in config.php.
+ *
+ * Usage:
+ *   php bin/register-shipyard-update-job.php
+ *
+ * Registered with interval=60s, allow_concurrent=0 (lease lock → single runner),
+ * timeout=600s (heartbeat extends it during large uploads). Editable afterward in
+ * Kyte Shipyard › System › Cron Jobs.
+ */
+
+require_once __DIR__ . '/bootstrap.php';
+
+use Kyte\Core\DBI;
+
+echo "============================================\n";
+echo "Shipyard Update Job Registration\n";
+echo "============================================\n\n";
+
+try {
+	$jobFile = dirname(__DIR__) . '/src/Cron/ShipyardUpdateWorker.php';
+
+	if (!file_exists($jobFile)) {
+		throw new \Exception("Job file not found: {$jobFile}");
+	}
+
+	$code = file_get_contents($jobFile);
+	echo "✓ Job code loaded (" . strlen($code) . " bytes)\n";
+
+	$compressed = bzcompress($code);
+	echo "✓ Code compressed (" . strlen($compressed) . " bytes)\n";
+
+	$jobName        = 'ShipyardUpdateWorker';
+	$jobDescription = 'Drains pending KyteShipyardUpdate requests: downloads the latest Shipyard build, uploads it to the Shipyard S3 bucket, and invalidates the Shipyard CloudFront distribution. Replaces the kyte-lambda-update-shipyard Lambda.';
+
+	// System-level job: application IS NULL, kyte_account = 0.
+	$sql = "SELECT id FROM CronJob WHERE name = ? AND application IS NULL AND (kyte_account = 0 OR kyte_account = 1) AND deleted = 0";
+	$existing = DBI::prepared_query($sql, 's', [$jobName]);
+
+	if (!empty($existing)) {
+		echo "\n⚠ Job already exists (ID: {$existing[0]['id']})\n";
+		echo "Would you like to update it? (y/n): ";
+		$handle = fopen("php://stdin", "r");
+		$response = trim(fgets($handle));
+		fclose($handle);
+
+		if (strtolower($response) !== 'y') {
+			echo "Cancelled.\n";
+			exit(0);
+		}
+
+		$sql = "
+			UPDATE CronJob
+			SET code = ?,
+				description = ?,
+				kyte_account = 0,
+				date_modified = UNIX_TIMESTAMP()
+			WHERE id = ?
+		";
+		DBI::prepared_query($sql, 'ssi', [$compressed, $jobDescription, $existing[0]['id']]);
+		echo "✓ Job updated (ID: {$existing[0]['id']})\n";
+
+	} else {
+		// interval=60s, enabled, timeout=600s, allow_concurrent=0, low retries
+		// (a failed update is recorded on the request row, not retried as a job).
+		$sql = "
+			INSERT INTO CronJob (
+				name, description, code, schedule_type, interval_seconds,
+				enabled, timeout_seconds, allow_concurrent, max_retries,
+				retry_strategy, retry_delay_seconds, notify_on_failure,
+				notify_after_failures, notify_on_dead_letter,
+				kyte_account, application, date_created
+			) VALUES (
+				?, ?, ?, 'interval', 60,
+				1, 600, 0, 1,
+				'exponential', 60, 0,
+				3, 0,
+				0, NULL, UNIX_TIMESTAMP()
+			)
+		";
+		DBI::prepared_query($sql, 'sss', [$jobName, $jobDescription, $compressed]);
+
+		$jobId = DBI::insert_id();
+		echo "✓ Job created (ID: {$jobId})\n";
+	}
+
+	echo "\n============================================\n";
+	echo "Registration Complete!\n";
+	echo "============================================\n\n";
+
+	echo "The job runs every 60 seconds. Ensure the cron worker daemon is running:\n\n";
+	echo "  php bin/cron-worker.php\n\n";
+	echo "Set KYTE_SHIPYARD_S3 and KYTE_SHIPYARD_CF in config.php if you haven't yet.\n";
+	echo "Manage the job in Kyte Shipyard: System > Cron Jobs\n\n";
+
+} catch (\Exception $e) {
+	echo "\n❌ ERROR: " . $e->getMessage() . "\n";
+	echo $e->getTraceAsString() . "\n";
+	exit(1);
+}

--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,7 @@
         "ext-curl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",
+        "ext-zip": "*",
         "aws/aws-sdk-php": "^3.101",
         "stripe/stripe-php": "^7.2",
         "dragonmantank/cron-expression": "^3.3",

--- a/docs/framework/aws-integration.md
+++ b/docs/framework/aws-integration.md
@@ -399,7 +399,6 @@ echo "Message published: $messageId";
 Kyte uses SNS for system notifications. Configure these in your config:
 
 ```php
-define('KYTE_USE_SNS', true);
 define('SNS_REGION', 'us-east-1');
 define('SNS_QUEUE_SITE_MANAGEMENT', 'arn:aws:sns:...:site-management');
 define('SNS_KYTE_SHIPYARD_UPDATE', 'arn:aws:sns:...:shipyard-updates');
@@ -802,10 +801,6 @@ class InventoryController extends ModelController
 
     private function publishLowStockAlert($productId, $productName, $quantity)
     {
-        if (!KYTE_USE_SNS) {
-            return;
-        }
-
         try {
             $credentials = new \Kyte\Aws\Credentials(SNS_REGION);
             $sns = new \Kyte\Aws\Sns($credentials);

--- a/migrations/4.12.0_shipyard_update.sql
+++ b/migrations/4.12.0_shipyard_update.sql
@@ -1,0 +1,53 @@
+-- =========================================================================
+-- Kyte v4.12.0 - KyteShipyardUpdate (async Shipyard self-update) - KYTE-#201
+-- =========================================================================
+-- IMPORTANT: Backup your database before running this migration.
+--
+-- Tracks Shipyard dashboard update requests + outcomes. The dashboard enqueues
+-- a row (status='pending') via KyteShipyardUpdateController; the
+-- ShipyardUpdateWorker cron job claims it (pending -> running) and performs the
+-- download/extract/upload/CloudFront-invalidate out-of-band, so a Cloudflare
+-- (~100s, non-enterprise) or ALB request timeout can't kill a long update.
+-- Replaces the SNS -> kyte-lambda-update-shipyard path.
+--
+-- Idempotency: the controller refuses to enqueue a second row while one is
+-- pending/running (request dedup); the cron worker runs with allow_concurrent=0
+-- (lease lock) and claims rows with a guarded pending->running UPDATE
+-- (execution dedup).
+--
+-- After this migration, register the worker:  php bin/register-shipyard-update-job.php
+-- and set KYTE_SHIPYARD_S3 / KYTE_SHIPYARD_CF in config.php.
+--
+-- See src/Mvc/Model/KyteShipyardUpdate.php, src/Cron/ShipyardUpdateWorker.php.
+-- =========================================================================
+
+CREATE TABLE IF NOT EXISTS `KyteShipyardUpdate` (
+    `id`                     BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+
+    `current_version`        VARCHAR(20)  DEFAULT NULL COMMENT 'Version the dashboard reported at request time',
+    `requested_version`      VARCHAR(20)  DEFAULT NULL COMMENT 'Latest CDN version we intend to deploy',
+    `deployed_version`       VARCHAR(20)  DEFAULT NULL COMMENT 'Version last successfully published',
+
+    `status`                 VARCHAR(20)  NOT NULL DEFAULT 'pending' COMMENT 'pending|running|complete|failed',
+    `message`                TEXT         DEFAULT NULL COMMENT 'Result or error detail for the dashboard',
+
+    `files_uploaded`         INT UNSIGNED NOT NULL DEFAULT 0,
+    `files_failed`           INT UNSIGNED NOT NULL DEFAULT 0,
+    `cloudfront_invalidated` TINYINT UNSIGNED NOT NULL DEFAULT 0,
+
+    `started_at`             BIGINT UNSIGNED DEFAULT NULL,
+    `finished_at`            BIGINT UNSIGNED DEFAULT NULL,
+
+    `kyte_account`           BIGINT UNSIGNED NOT NULL,
+
+    `created_by`             BIGINT UNSIGNED DEFAULT NULL,
+    `date_created`           BIGINT UNSIGNED DEFAULT NULL,
+    `modified_by`            BIGINT UNSIGNED DEFAULT NULL,
+    `date_modified`          BIGINT UNSIGNED DEFAULT NULL,
+    `deleted_by`             BIGINT UNSIGNED DEFAULT NULL,
+    `date_deleted`           BIGINT UNSIGNED DEFAULT NULL,
+    `deleted`                TINYINT UNSIGNED NOT NULL DEFAULT 0,
+
+    KEY `idx_account`        (`kyte_account`),
+    KEY `idx_status`         (`status`, `deleted`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -391,18 +391,6 @@ parameters:
 			path: src/Mvc/Controller/KyteScriptVersionController.php
 
 		-
-			message: '#^Constant SNS_KYTE_SHIPYARD_UPDATE not found\.$#'
-			identifier: constant.notFound
-			count: 1
-			path: src/Mvc/Controller/KyteShipyardUpdateController.php
-
-		-
-			message: '#^Constant SNS_REGION not found\.$#'
-			identifier: constant.notFound
-			count: 1
-			path: src/Mvc/Controller/KyteShipyardUpdateController.php
-
-		-
 			message: '#^Constant SNS_QUEUE_SITE_MANAGEMENT not found\.$#'
 			identifier: constant.notFound
 			count: 2

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -271,24 +271,6 @@ parameters:
 			path: src/Mvc/Controller/AIErrorDeduplicationController.php
 
 		-
-			message: '#^Constant KYTE_USE_SNS not found\.$#'
-			identifier: constant.notFound
-			count: 1
-			path: src/Mvc/Controller/ApplicationController.php
-
-		-
-			message: '#^Constant SNS_QUEUE_SITE_MANAGEMENT not found\.$#'
-			identifier: constant.notFound
-			count: 1
-			path: src/Mvc/Controller/ApplicationController.php
-
-		-
-			message: '#^Constant SNS_REGION not found\.$#'
-			identifier: constant.notFound
-			count: 1
-			path: src/Mvc/Controller/ApplicationController.php
-
-		-
 			message: '#^Variable \$credential might not be defined\.$#'
 			identifier: variable.undefined
 			count: 1
@@ -367,45 +349,9 @@ parameters:
 			path: src/Mvc/Controller/KyteFunctionVersionController.php
 
 		-
-			message: '#^Constant KYTE_USE_SNS not found\.$#'
-			identifier: constant.notFound
-			count: 2
-			path: src/Mvc/Controller/KyteLibraryController.php
-
-		-
-			message: '#^Constant SNS_QUEUE_SITE_MANAGEMENT not found\.$#'
-			identifier: constant.notFound
-			count: 2
-			path: src/Mvc/Controller/KyteLibraryController.php
-
-		-
-			message: '#^Constant SNS_REGION not found\.$#'
-			identifier: constant.notFound
-			count: 2
-			path: src/Mvc/Controller/KyteLibraryController.php
-
-		-
 			message: '#^Constant KYTE_JS_CDN not found\.$#'
 			identifier: constant.notFound
 			count: 1
-			path: src/Mvc/Controller/KytePageController.php
-
-		-
-			message: '#^Constant KYTE_USE_SNS not found\.$#'
-			identifier: constant.notFound
-			count: 3
-			path: src/Mvc/Controller/KytePageController.php
-
-		-
-			message: '#^Constant SNS_QUEUE_SITE_MANAGEMENT not found\.$#'
-			identifier: constant.notFound
-			count: 3
-			path: src/Mvc/Controller/KytePageController.php
-
-		-
-			message: '#^Constant SNS_REGION not found\.$#'
-			identifier: constant.notFound
-			count: 3
 			path: src/Mvc/Controller/KytePageController.php
 
 		-
@@ -413,24 +359,6 @@ parameters:
 			identifier: variable.undefined
 			count: 2
 			path: src/Mvc/Controller/KytePageController.php
-
-		-
-			message: '#^Constant KYTE_USE_SNS not found\.$#'
-			identifier: constant.notFound
-			count: 1
-			path: src/Mvc/Controller/KytePageDataController.php
-
-		-
-			message: '#^Constant SNS_QUEUE_SITE_MANAGEMENT not found\.$#'
-			identifier: constant.notFound
-			count: 1
-			path: src/Mvc/Controller/KytePageDataController.php
-
-		-
-			message: '#^Constant SNS_REGION not found\.$#'
-			identifier: constant.notFound
-			count: 1
-			path: src/Mvc/Controller/KytePageDataController.php
 
 		-
 			message: '#^Caught class Kyte\\Mvc\\Controller\\Exception not found\.$#'
@@ -455,24 +383,6 @@ parameters:
 			identifier: constant.notFound
 			count: 1
 			path: src/Mvc/Controller/KytePasswordResetController.php
-
-		-
-			message: '#^Constant KYTE_USE_SNS not found\.$#'
-			identifier: constant.notFound
-			count: 2
-			path: src/Mvc/Controller/KyteScriptController.php
-
-		-
-			message: '#^Constant SNS_QUEUE_SITE_MANAGEMENT not found\.$#'
-			identifier: constant.notFound
-			count: 2
-			path: src/Mvc/Controller/KyteScriptController.php
-
-		-
-			message: '#^Constant SNS_REGION not found\.$#'
-			identifier: constant.notFound
-			count: 2
-			path: src/Mvc/Controller/KyteScriptController.php
 
 		-
 			message: '#^Caught class Kyte\\Mvc\\Controller\\Exception not found\.$#'
@@ -523,24 +433,6 @@ parameters:
 			path: src/Mvc/Controller/ModelController.php
 
 		-
-			message: '#^Constant KYTE_USE_SNS not found\.$#'
-			identifier: constant.notFound
-			count: 1
-			path: src/Mvc/Controller/NavigationController.php
-
-		-
-			message: '#^Constant SNS_QUEUE_SITE_MANAGEMENT not found\.$#'
-			identifier: constant.notFound
-			count: 1
-			path: src/Mvc/Controller/NavigationController.php
-
-		-
-			message: '#^Constant SNS_REGION not found\.$#'
-			identifier: constant.notFound
-			count: 1
-			path: src/Mvc/Controller/NavigationController.php
-
-		-
 			message: '#^Variable \$nav might not be defined\.$#'
 			identifier: variable.undefined
 			count: 11
@@ -569,24 +461,6 @@ parameters:
 			identifier: constant.notFound
 			count: 2
 			path: src/Mvc/Controller/SessionController.php
-
-		-
-			message: '#^Constant KYTE_USE_SNS not found\.$#'
-			identifier: constant.notFound
-			count: 1
-			path: src/Mvc/Controller/SideNavController.php
-
-		-
-			message: '#^Constant SNS_QUEUE_SITE_MANAGEMENT not found\.$#'
-			identifier: constant.notFound
-			count: 1
-			path: src/Mvc/Controller/SideNavController.php
-
-		-
-			message: '#^Constant SNS_REGION not found\.$#'
-			identifier: constant.notFound
-			count: 1
-			path: src/Mvc/Controller/SideNavController.php
 
 		-
 			message: '#^Variable \$nav might not be defined\.$#'

--- a/sample-config.php
+++ b/sample-config.php
@@ -5,6 +5,13 @@
     /* General Application Settings */
     define('APP_NAME', ''); // Name of the application
     define('SHIPYARD_URL', ''); // Base URL of Kyte Shipyard
+    // Shipyard self-update target. The dashboard enqueues an update; the
+    // ShipyardUpdateWorker cron job publishes the latest build here and
+    // invalidates the distribution (replaces the kyte-lambda-update-shipyard Lambda).
+    // Register the worker once: php bin/register-shipyard-update-job.php
+    define('KYTE_SHIPYARD_S3', ''); // S3 bucket hosting the Shipyard dashboard
+    define('KYTE_SHIPYARD_CF', ''); // CloudFront distribution id for the Shipyard dashboard
+    // define('KYTE_SHIPYARD_REGION', 'us-east-1'); // Optional; defaults to us-east-1
 	define('APP_EMAIL', ''); // Application email address
     define('APP_SES_REGION', ''); // AWS SES region for sending emails')
 	define('SUPPORT_EMAIL', ''); // Support email address

--- a/sample-config.php
+++ b/sample-config.php
@@ -27,7 +27,6 @@
     define('SNS_KYTE_SHIPYARD_UPDATE', ''); // SNS queue for Kyte Shipyard updates
 
     /* Kyte Framework Specific Settings */
-    define('KYTE_USE_SNS', true); // Enable/Disable AWS SNS integration
     define('DEBUG', false); // Enable/Disable debug mode
     define('S3_DEBUG', false); // Enable/Disable S3 debug mode
     define('ALLOW_ENC_HANDOFF', true); // Allow encrypted handoff

--- a/src/Core/Api.php
+++ b/src/Core/Api.php
@@ -173,7 +173,6 @@ class Api
 		'USE_SESSION_MAP' => false,
 		'CHECK_SYNTAX_ON_IMPORT' => false,
 		'STRICT_TYPING' => true,
-		'KYTE_USE_SNS' => false,
 		'AUTH_STRATEGY_DISPATCHER' => 'off',
 		'KYTE_ACTIVITY_LOG_MAX_FIELD_BYTES' => 16384,
 	];

--- a/src/Core/Api.php
+++ b/src/Core/Api.php
@@ -401,10 +401,13 @@ class Api
 		if ($host == null) {
 			$host = KYTE_DB_HOST;
 		}
-		//
-		if (\Kyte\Core\DBI::$dbUser == $username && \Kyte\Core\DBI::$dbName == $database && \Kyte\Core\DBI::$dbHost == $host) {
+		// already pointed at this app DB — keep the live connection, nothing to do
+		if (\Kyte\Core\DBI::$dbUserApp == $username && \Kyte\Core\DBI::$dbNameApp == $database && \Kyte\Core\DBI::$dbHostApp == $host) {
 			return;
 		}
+
+		// target changed — drop the stale app handle so the next query reconnects to the new DB
+		\Kyte\Core\DBI::closeApp();
 
 		\Kyte\Core\DBI::setDbNameApp($database);
 		\Kyte\Core\DBI::setDbUserApp($username);

--- a/src/Core/DBI.php
+++ b/src/Core/DBI.php
@@ -155,10 +155,10 @@ class DBI {
 		self::setDbPasswordApp($dbPasswordApp);
 		self::setDbHostApp($dbHostApp);
 		self::setDbNameApp($dbNameApp);
-		self::setCharsetApp($charsetApp);
-		self::setEngineApp($engineApp);
+		self::setCharset($charset);
+		self::setEngine($engine);
 
-		return self::connect();
+		return self::connectApp();
 	}
 
 	/*
@@ -234,12 +234,33 @@ class DBI {
 	{
 		if (!self::$dbConnApp) {
 			try {
-				self::$dbConnApp = new \mysqli(self::$dbHostApp, self::$dbUserApp, self::$dbPasswordApp, self::$dbNameApp);
+				if (defined('KYTE_DB_CA_BUNDLE')) {
+					self::$dbConnApp = new \mysqli();
+					self::$dbConnApp->ssl_set(null, null, KYTE_DB_CA_BUNDLE, null, null);
+					if (!self::$dbConnApp->real_connect(self::$dbHostApp, self::$dbUserApp, self::$dbPasswordApp, self::$dbNameApp, null, null, MYSQLI_CLIENT_SSL)) {
+						throw new \Exception('App SSL connection failed: ' . self::$dbConnApp->connect_error, self::$dbConnApp->connect_errno);
+					}
+				} else {
+					self::$dbConnApp = new \mysqli(self::$dbHostApp, self::$dbUserApp, self::$dbPasswordApp, self::$dbNameApp);
+				}
 				// set charset to utf8mb4
 				if ( TRUE !== self::$dbConnApp->set_charset( self::$charset ) )
 					throw new \Exception( self::$dbConnApp->error, self::$dbConnApp->errno );
-			} catch (mysqli_sql_exception $e) {
-				throw $e;
+			} catch (\Exception $e) {
+				// If SSL connection fails, fall back to non-SSL connection
+				if (defined('KYTE_DB_CA_BUNDLE') && (self::$dbConnApp === null || self::$dbConnApp->connect_errno)) {
+					error_log("App SSL connection failed, falling back to non-SSL: " . $e->getMessage());
+					$reportLevel = mysqli_report(MYSQLI_REPORT_OFF);
+					self::$dbConnApp = new \mysqli(self::$dbHostApp, self::$dbUserApp, self::$dbPasswordApp, self::$dbNameApp);
+					mysqli_report($reportLevel);
+					if (self::$dbConnApp->connect_error) {
+						throw new \Exception('App database connection failed (both SSL and non-SSL): ' . self::$dbConnApp->connect_error, self::$dbConnApp->connect_errno);
+					}
+					if ( TRUE !== self::$dbConnApp->set_charset( self::$charset ) )
+						throw new \Exception( self::$dbConnApp->error, self::$dbConnApp->errno );
+				} else {
+					throw $e;
+				}
 			}
 		}
 

--- a/src/Core/DBI.php
+++ b/src/Core/DBI.php
@@ -150,17 +150,6 @@ class DBI {
 		return self::connect();
 	}
 
-	public static function dbInitApp($dbUserApp, $dbPasswordApp, $dbHostApp, $dbNameApp, $charset, $engine) {
-		self::setDbUserApp($dbUserApp);
-		self::setDbPasswordApp($dbPasswordApp);
-		self::setDbHostApp($dbHostApp);
-		self::setDbNameApp($dbNameApp);
-		self::setCharset($charset);
-		self::setEngine($engine);
-
-		return self::connectApp();
-	}
-
 	/*
 	 * Connect to database
 	 *

--- a/src/Cron/ShipyardUpdateWorker.php
+++ b/src/Cron/ShipyardUpdateWorker.php
@@ -1,0 +1,350 @@
+<?php
+
+namespace Kyte\Cron;
+
+use Kyte\Core\CronJobBase;
+use Kyte\Core\DBI;
+
+/**
+ * ShipyardUpdateWorker
+ *
+ * Performs the install's Kyte Shipyard dashboard self-update out-of-band, draining
+ * pending rows from the KyteShipyardUpdate table. Replaces the SNS ->
+ * kyte-lambda-update-shipyard Lambda (KYTE-#201).
+ *
+ * Why a cron job and not a synchronous controller action: the work (download +
+ * extract + upload N files + CloudFront invalidation) routinely exceeds the
+ * ~100s Cloudflare non-enterprise request ceiling (and ALB idle timeouts), so it
+ * must run off the request path.
+ *
+ * Idempotency — two layers:
+ *   1. Request dedup is enforced by the controller (it won't enqueue a second row
+ *      while one is pending/running).
+ *   2. Execution dedup here: the job is registered with allow_concurrent=0 (the
+ *      CronWorker lease lock keeps a single instance running), and each row is
+ *      claimed with a guarded `pending -> running` UPDATE — only the worker whose
+ *      affected_rows() == 1 owns the row, so even a double-tick can't double-run.
+ *
+ * Bugs the old Lambda had, fixed inherently here: it crashed uploading .map/dir
+ * entries (boto3 ContentType=None) and invalidated a stale/nonexistent
+ * distribution from an env var. We set an explicit per-extension Content-Type
+ * (omitting unknown types rather than crashing) and invalidate the distribution
+ * from config (KYTE_SHIPYARD_CF).
+ */
+class ShipyardUpdateWorker extends CronJobBase
+{
+	private const CHANGELOG_URL = 'https://cdn.keyqcloud.com/kyte/shipyard/archive/CHANGELOG.md';
+	private const ZIP_URL       = 'https://cdn.keyqcloud.com/kyte/shipyard/stable/kyte-shipyard.zip';
+
+	/**
+	 * Content-Type by file extension. The Shipyard is a static SPA: JS must be
+	 * served as application/javascript and CSS as text/css. Unknown extensions
+	 * (e.g. .map) return null and S3::write() lets S3 use its default — never a
+	 * hard failure (the Lambda's ContentType=None crash).
+	 */
+	private const CONTENT_TYPES = [
+		'html'  => 'text/html; charset=utf-8',
+		'htm'   => 'text/html; charset=utf-8',
+		'js'    => 'application/javascript',
+		'mjs'   => 'application/javascript',
+		'css'   => 'text/css',
+		'json'  => 'application/json',
+		'map'   => 'application/json',
+		'svg'   => 'image/svg+xml',
+		'png'   => 'image/png',
+		'jpg'   => 'image/jpeg',
+		'jpeg'  => 'image/jpeg',
+		'gif'   => 'image/gif',
+		'ico'   => 'image/x-icon',
+		'webp'  => 'image/webp',
+		'woff'  => 'font/woff',
+		'woff2' => 'font/woff2',
+		'ttf'   => 'font/ttf',
+		'eot'   => 'application/vnd.ms-fontobject',
+		'txt'   => 'text/plain; charset=utf-8',
+		'xml'   => 'application/xml',
+		'wasm'  => 'application/wasm',
+	];
+
+	public function execute()
+	{
+		// Claim the oldest pending request, if any. One per tick keeps each run
+		// bounded; there is at most one Shipyard per install so this is plenty.
+		$row = DBI::prepared_query(
+			"SELECT * FROM KyteShipyardUpdate WHERE status = 'pending' AND deleted = 0 ORDER BY date_created ASC, id ASC LIMIT 1",
+			'',
+			[]
+		);
+		if (empty($row)) {
+			return json_encode(['claimed' => false, 'message' => 'No pending Shipyard updates.']);
+		}
+		$row = $row[0];
+		$id  = (int) $row['id'];
+
+		// Guarded pending -> running. Only the worker that flips it owns the row.
+		DBI::prepared_query(
+			"UPDATE KyteShipyardUpdate SET status = 'running', started_at = UNIX_TIMESTAMP(), date_modified = UNIX_TIMESTAMP() WHERE id = ? AND status = 'pending'",
+			'i',
+			[$id]
+		);
+		if (DBI::affected_rows() !== 1) {
+			$this->log("Row #{$id} was claimed by another worker; skipping.");
+			return json_encode(['claimed' => false, 'message' => 'Already claimed.']);
+		}
+		$this->log("Claimed Shipyard update request #{$id}.");
+
+		try {
+			$result = $this->process($row);
+			$this->finish($id, 'complete', $result['message'], $result);
+			return json_encode(['claimed' => true, 'id' => $id] + $result);
+		} catch (\Throwable $e) {
+			$this->log("Shipyard update #{$id} failed: " . $e->getMessage());
+			$this->finish($id, 'failed', $e->getMessage(), []);
+			// Do not rethrow: the failure is recorded on the row, and rethrowing
+			// would push the cron JOB itself toward retries/DLQ for what is really
+			// per-request data. The user can re-trigger from the dashboard.
+			return json_encode(['claimed' => true, 'id' => $id, 'status' => 'failed', 'message' => $e->getMessage()]);
+		}
+	}
+
+	/**
+	 * Do the actual update for a claimed row. Returns a result array (message +
+	 * counters) on success; throws on hard failure.
+	 *
+	 * @param array<string,mixed> $row
+	 * @return array<string,mixed>
+	 */
+	private function process($row): array
+	{
+		if (!defined('KYTE_SHIPYARD_S3') || !defined('KYTE_SHIPYARD_CF') || !KYTE_SHIPYARD_S3 || !KYTE_SHIPYARD_CF) {
+			throw new \Exception('Shipyard update is not configured: define KYTE_SHIPYARD_S3 and KYTE_SHIPYARD_CF in config.');
+		}
+		if (!class_exists('\ZipArchive')) {
+			throw new \Exception('Shipyard update requires the PHP zip extension (ext-zip / ZipArchive).');
+		}
+
+		$currentVersion = $row['current_version'];
+
+		$latestVersion = $this->getLatestVersion();
+		if ($latestVersion === null) {
+			throw new \Exception('Unable to determine the latest Shipyard version from CHANGELOG.');
+		}
+
+		// Re-check at run time: the request may have raced another update, or the
+		// dashboard was already current. Record the deployed version and stop.
+		if ($latestVersion === $currentVersion) {
+			return [
+				'updated'                => false,
+				'deployed_version'       => $latestVersion,
+				'files_uploaded'         => 0,
+				'files_failed'           => 0,
+				'cloudfront_invalidated' => false,
+				'message'                => "Shipyard already up to date ({$latestVersion}); nothing to deploy.",
+			];
+		}
+
+		$tmpDir = $this->downloadAndExtract();
+
+		try {
+			$region     = defined('KYTE_SHIPYARD_REGION') ? KYTE_SHIPYARD_REGION : 'us-east-1';
+			$credential = new \Kyte\Aws\Credentials($region);
+			$s3         = new \Kyte\Aws\S3($credential, KYTE_SHIPYARD_S3);
+
+			$uploaded = 0;
+			$failed   = 0;
+			$i        = 0;
+			foreach ($this->iterateFiles($tmpDir) as $key => $absolutePath) {
+				try {
+					$ext         = strtolower(pathinfo($key, PATHINFO_EXTENSION));
+					$contentType = self::CONTENT_TYPES[$ext] ?? null;
+					$s3->write($key, file_get_contents($absolutePath), $contentType);
+					$uploaded++;
+				} catch (\Throwable $e) {
+					$failed++;
+					$this->log("Failed to upload {$key}: " . $e->getMessage());
+				}
+				// Extend the lease periodically so a large build isn't flagged as
+				// a timed-out execution mid-upload.
+				if ((++$i % 25) === 0) {
+					$this->heartbeat();
+				}
+			}
+
+			$invalidated = false;
+			try {
+				$cf = new \Kyte\Aws\CloudFront($credential);
+				$cf->createInvalidation(KYTE_SHIPYARD_CF, ['/*']);
+				$invalidated = true;
+			} catch (\Throwable $e) {
+				$this->log("CloudFront invalidation failed (best-effort): " . $e->getMessage());
+			}
+
+			return [
+				'updated'                => true,
+				'deployed_version'       => $latestVersion,
+				'files_uploaded'         => $uploaded,
+				'files_failed'           => $failed,
+				'cloudfront_invalidated' => $invalidated,
+				'message'                => "Shipyard updated to {$latestVersion} ({$uploaded} file(s) uploaded"
+					. ($failed ? ", {$failed} failed" : '') . ')'
+					. ($invalidated ? '.' : '; CloudFront invalidation failed (will catch up at TTL).'),
+			];
+		} finally {
+			$this->deleteDir($tmpDir);
+		}
+	}
+
+	/**
+	 * Write the terminal state back to the row.
+	 *
+	 * @param array<string,mixed> $result
+	 */
+	private function finish(int $id, string $status, string $message, array $result): void
+	{
+		$sql = "
+			UPDATE KyteShipyardUpdate
+			SET status = ?,
+				message = ?,
+				deployed_version = COALESCE(?, deployed_version),
+				files_uploaded = ?,
+				files_failed = ?,
+				cloudfront_invalidated = ?,
+				finished_at = UNIX_TIMESTAMP(),
+				date_modified = UNIX_TIMESTAMP()
+			WHERE id = ?
+		";
+		DBI::prepared_query($sql, 'sssiiii', [
+			$status,
+			$message,
+			$result['deployed_version'] ?? null,
+			(int) ($result['files_uploaded'] ?? 0),
+			(int) ($result['files_failed'] ?? 0),
+			!empty($result['cloudfront_invalidated']) ? 1 : 0,
+			$id,
+		]);
+		$this->log("Shipyard update #{$id} -> {$status}: {$message}");
+	}
+
+	/**
+	 * Fetch the CDN changelog and return the first `## X.Y.Z` version, or null.
+	 */
+	private function getLatestVersion(): ?string
+	{
+		$content = $this->httpGet(self::CHANGELOG_URL);
+		if ($content === null) {
+			return null;
+		}
+		if (preg_match('/##\s*(\d+\.\d+\.\d+)/', $content, $m)) {
+			return $m[1];
+		}
+		return null;
+	}
+
+	/**
+	 * Download the stable zip and extract it to a fresh temp directory (caller
+	 * deletes it). Returns the temp directory path.
+	 */
+	private function downloadAndExtract(): string
+	{
+		$zipData = $this->httpGet(self::ZIP_URL);
+		if ($zipData === null || $zipData === '') {
+			throw new \Exception('Failed to download the Shipyard build archive.');
+		}
+
+		$tmpDir = rtrim(sys_get_temp_dir(), '/\\') . DIRECTORY_SEPARATOR . 'kyte-shipyard-' . uniqid('', true);
+		if (!mkdir($tmpDir, 0700, true) && !is_dir($tmpDir)) {
+			throw new \Exception("Failed to create temp directory for Shipyard update: {$tmpDir}");
+		}
+
+		$zipPath = $tmpDir . DIRECTORY_SEPARATOR . 'kyte-shipyard.zip';
+		if (file_put_contents($zipPath, $zipData) === false) {
+			$this->deleteDir($tmpDir);
+			throw new \Exception('Failed to write the Shipyard build archive to disk.');
+		}
+
+		$zip = new \ZipArchive();
+		if ($zip->open($zipPath) !== true) {
+			$this->deleteDir($tmpDir);
+			throw new \Exception('Failed to open the Shipyard build archive.');
+		}
+		if (!$zip->extractTo($tmpDir)) {
+			$zip->close();
+			$this->deleteDir($tmpDir);
+			throw new \Exception('Failed to extract the Shipyard build archive.');
+		}
+		$zip->close();
+
+		// The archive itself is not an asset to publish.
+		@unlink($zipPath);
+
+		return $tmpDir;
+	}
+
+	/**
+	 * Yield [s3Key => absolutePath] for every file under $dir (recursively),
+	 * skipping directories. The S3 key is forward-slashed relative to $dir.
+	 *
+	 * @return \Generator<string, string>
+	 */
+	private function iterateFiles(string $dir): \Generator
+	{
+		$iterator = new \RecursiveIteratorIterator(
+			new \RecursiveDirectoryIterator($dir, \FilesystemIterator::SKIP_DOTS),
+			\RecursiveIteratorIterator::LEAVES_ONLY
+		);
+		$prefixLen = strlen(rtrim($dir, '/\\')) + 1;
+		foreach ($iterator as $file) {
+			if ($file->isDir()) {
+				continue;
+			}
+			$absolute = $file->getPathname();
+			$key      = str_replace('\\', '/', substr($absolute, $prefixLen));
+			yield $key => $absolute;
+		}
+	}
+
+	/**
+	 * Best-effort HTTP GET via curl. Returns the body on HTTP 2xx, else null.
+	 */
+	private function httpGet(string $url): ?string
+	{
+		$ch = curl_init($url);
+		if ($ch === false) {
+			return null;
+		}
+		curl_setopt_array($ch, [
+			CURLOPT_RETURNTRANSFER => true,
+			CURLOPT_FOLLOWLOCATION => true,
+			CURLOPT_TIMEOUT        => 120,
+			CURLOPT_CONNECTTIMEOUT => 15,
+		]);
+		$body   = curl_exec($ch);
+		$status = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+		$error  = curl_error($ch);
+		curl_close($ch);
+
+		if ($body === false || $status < 200 || $status >= 300) {
+			$this->log("GET {$url} failed (status {$status}): {$error}");
+			return null;
+		}
+		return $body;
+	}
+
+	/**
+	 * Recursively delete a directory tree. Best-effort cleanup of the temp dir.
+	 */
+	private function deleteDir(string $dir): void
+	{
+		if (!is_dir($dir)) {
+			return;
+		}
+		$iterator = new \RecursiveIteratorIterator(
+			new \RecursiveDirectoryIterator($dir, \FilesystemIterator::SKIP_DOTS),
+			\RecursiveIteratorIterator::CHILD_FIRST
+		);
+		foreach ($iterator as $file) {
+			$file->isDir() ? @rmdir($file->getPathname()) : @unlink($file->getPathname());
+		}
+		@rmdir($dir);
+	}
+}

--- a/src/Mvc/Controller/ApplicationController.php
+++ b/src/Mvc/Controller/ApplicationController.php
@@ -139,20 +139,8 @@ class ApplicationController extends ModelController
                         // every other site's cache stale. See KYTE-#181.
                         try {
                             $invalidationPaths = ['/*'];
-                            if (KYTE_USE_SNS) {
-                                $snsCredential = new \Kyte\Aws\Credentials(SNS_REGION);
-                                $sns = new \Kyte\Aws\Sns($snsCredential, SNS_QUEUE_SITE_MANAGEMENT);
-                                $sns->publish([
-                                    'action' => 'cf_invalidate',
-                                    'site_id' => $site->id,
-                                    'cf_id' => $site->cfDistributionId,
-                                    'cf_invalidation_paths' => $invalidationPaths,
-                                    'caller_id' => time(),
-                                ]);
-                            } else {
-                                $cf = new \Kyte\Aws\CloudFront($credential);
-                                $cf->createInvalidation($site->cfDistributionId, $invalidationPaths);
-                            }
+                            $cf = new \Kyte\Aws\CloudFront($credential);
+                            $cf->createInvalidation($site->cfDistributionId, $invalidationPaths);
                         } catch (\Throwable $e) {
                             error_log("Republish: CloudFront invalidation failed for site {$site->id}: " . $e->getMessage());
                         }

--- a/src/Mvc/Controller/KyteLibraryController.php
+++ b/src/Mvc/Controller/KyteLibraryController.php
@@ -104,21 +104,9 @@ class KyteLibraryController extends ModelController
                 $invalidationPaths = ['/*'];
                 // Best-effort: content already in S3; a failed invalidation must not fail the request.
                 try {
-                    if (KYTE_USE_SNS) {
-                        $credential = new \Kyte\Aws\Credentials(SNS_REGION);
-                        $sns = new \Kyte\Aws\Sns($credential, SNS_QUEUE_SITE_MANAGEMENT);
-                        $sns->publish([
-                            'action' => 'cf_invalidate',
-                            'site_id' => $r['site']['id'],
-                            'cf_id' => $r['site']['cfDistributionId'],
-                            'cf_invalidation_paths' => $invalidationPaths,
-                            'caller_id' => time(),
-                        ]);
-                    } else {
-                        // invalidate CF
-                        $cf = new \Kyte\Aws\CloudFront($credential);
-                        $cf->createInvalidation($r['site']['cfDistributionId'], $invalidationPaths);
-                    }
+                    // invalidate CF
+                    $cf = new \Kyte\Aws\CloudFront($credential);
+                    $cf->createInvalidation($r['site']['cfDistributionId'], $invalidationPaths);
                 } catch (\Throwable $e) {
                     error_log("CloudFront invalidation failed (best-effort): " . $e->getMessage());
                 }
@@ -183,21 +171,9 @@ class KyteLibraryController extends ModelController
                 $invalidationPaths = ['/*'];
                 // Best-effort: content already in S3; a failed invalidation must not fail the request.
                 try {
-                    if (KYTE_USE_SNS) {
-                        $credential = new \Kyte\Aws\Credentials(SNS_REGION);
-                        $sns = new \Kyte\Aws\Sns($credential, SNS_QUEUE_SITE_MANAGEMENT);
-                        $sns->publish([
-                            'action' => 'cf_invalidate',
-                            'site_id' => $d['site']['id'],
-                            'cf_id' => $d['site']['cfDistributionId'],
-                            'cf_invalidation_paths' => $invalidationPaths,
-                            'caller_id' => time(),
-                        ]);
-                    } else {
-                        // invalidate CF
-                        $cf = new \Kyte\Aws\CloudFront($credential);
-                        $cf->createInvalidation($d['site']['cfDistributionId'], $invalidationPaths);
-                    }
+                    // invalidate CF
+                    $cf = new \Kyte\Aws\CloudFront($credential);
+                    $cf->createInvalidation($d['site']['cfDistributionId'], $invalidationPaths);
                 } catch (\Throwable $e) {
                     error_log("CloudFront invalidation failed (best-effort): " . $e->getMessage());
                 }

--- a/src/Mvc/Controller/KytePageController.php
+++ b/src/Mvc/Controller/KytePageController.php
@@ -27,21 +27,9 @@ class KytePageController extends ModelController
                     $invalidationPaths = ['/*'];
                     // Best-effort: content already in S3; a failed invalidation must not fail the request.
                     try {
-                        if (KYTE_USE_SNS) {
-                            $credential = new \Kyte\Aws\Credentials(SNS_REGION);
-                            $sns = new \Kyte\Aws\Sns($credential, SNS_QUEUE_SITE_MANAGEMENT);
-                            $sns->publish([
-                                'action' => 'cf_invalidate',
-                                'site_id' => $d['site']['id'],
-                                'cf_id' => $d['site']['cfDistributionId'],
-                                'cf_invalidation_paths' => $invalidationPaths,
-                                'caller_id' => time(),
-                            ]);
-                        } else {
-                            // invalidate CF
-                            $cf = new \Kyte\Aws\CloudFront($credential);
-                            $cf->createInvalidation($d['site']['cfDistributionId'], $invalidationPaths);
-                        }
+                        // invalidate CF
+                        $cf = new \Kyte\Aws\CloudFront($credential);
+                        $cf->createInvalidation($d['site']['cfDistributionId'], $invalidationPaths);
                     } catch (\Throwable $e) {
                         error_log("CloudFront invalidation failed (best-effort): " . $e->getMessage());
                     }
@@ -235,21 +223,9 @@ class KytePageController extends ModelController
                     $invalidationPaths = ['/*'];
                     // Best-effort: content already in S3; a failed invalidation must not fail the request.
                     try {
-                        if (KYTE_USE_SNS) {
-                            $credential = new \Kyte\Aws\Credentials(SNS_REGION);
-                            $sns = new \Kyte\Aws\Sns($credential, SNS_QUEUE_SITE_MANAGEMENT);
-                            $sns->publish([
-                                'action' => 'cf_invalidate',
-                                'site_id' => $d['site']['id'],
-                                'cf_id' => $d['site']['cfDistributionId'],
-                                'cf_invalidation_paths' => $invalidationPaths,
-                                'caller_id' => time(),
-                            ]);
-                        } else {
-                            // invalidate CF
-                            $cf = new \Kyte\Aws\CloudFront($credential);
-                            $cf->createInvalidation($d['site']['cfDistributionId'], $invalidationPaths);
-                        }
+                        // invalidate CF
+                        $cf = new \Kyte\Aws\CloudFront($credential);
+                        $cf->createInvalidation($d['site']['cfDistributionId'], $invalidationPaths);
                     } catch (\Throwable $e) {
                         error_log("CloudFront invalidation failed (best-effort): " . $e->getMessage());
                     }
@@ -464,22 +440,9 @@ class KytePageController extends ModelController
         // Invalidate CloudFront cache
         // Best-effort: content already in S3; a failed invalidation must not fail the publish.
         try {
-            if (KYTE_USE_SNS) {
-                // Use SNS for asynchronous invalidation
-                $snsCredential = new \Kyte\Aws\Credentials(SNS_REGION);
-                $sns = new \Kyte\Aws\Sns($snsCredential, SNS_QUEUE_SITE_MANAGEMENT);
-                $sns->publish([
-                    'action' => 'cf_invalidate',
-                    'site_id' => $responseData['site']['id'],
-                    'cf_id' => $responseData['site']['cfDistributionId'],
-                    'cf_invalidation_paths' => $invalidationPaths,
-                    'caller_id' => time(),
-                ]);
-            } else {
-                // Direct CloudFront invalidation
-                $cf = new \Kyte\Aws\CloudFront($credential);
-                $cf->createInvalidation($responseData['site']['cfDistributionId'], $invalidationPaths);
-            }
+            // Direct CloudFront invalidation
+            $cf = new \Kyte\Aws\CloudFront($credential);
+            $cf->createInvalidation($responseData['site']['cfDistributionId'], $invalidationPaths);
         } catch (\Throwable $e) {
             error_log("CloudFront invalidation failed (best-effort): " . $e->getMessage());
         }

--- a/src/Mvc/Controller/KytePageDataController.php
+++ b/src/Mvc/Controller/KytePageDataController.php
@@ -89,21 +89,9 @@ class KytePageDataController extends ModelController
                     $invalidationPaths = ['/*'];
                     // Best-effort: content already in S3; a failed invalidation must not fail the request.
                     try {
-                        if (KYTE_USE_SNS) {
-                            $credential = new \Kyte\Aws\Credentials(SNS_REGION);
-                            $sns = new \Kyte\Aws\Sns($credential, SNS_QUEUE_SITE_MANAGEMENT);
-                            $sns->publish([
-                                'action' => 'cf_invalidate',
-                                'site_id' => $d['site']['id'],
-                                'cf_id' => $d['site']['cfDistributionId'],
-                                'cf_invalidation_paths' => $invalidationPaths,
-                                'caller_id' => time(),
-                            ]);
-                        } else {
-                            // invalidate CF
-                            $cf = new \Kyte\Aws\CloudFront($credential);
-                            $cf->createInvalidation($d['site']['cfDistributionId'], $invalidationPaths);
-                        }
+                        // invalidate CF
+                        $cf = new \Kyte\Aws\CloudFront($credential);
+                        $cf->createInvalidation($d['site']['cfDistributionId'], $invalidationPaths);
                     } catch (\Throwable $e) {
                         error_log("CloudFront invalidation failed (best-effort): " . $e->getMessage());
                     }

--- a/src/Mvc/Controller/KyteScriptController.php
+++ b/src/Mvc/Controller/KyteScriptController.php
@@ -658,26 +658,14 @@ class KyteScriptController extends ModelController
         $invalidationPaths = ['/*'];
         // Best-effort: the script is already published to S3; a failed CloudFront
         // invalidation (transient AWS error, missing distribution) must not fail
-        // the request. Log and continue. (KYTE_USE_SNS is the deprecated async path.)
+        // the request. Log and continue.
         try {
-            if (KYTE_USE_SNS) {
-                $credential = new \Kyte\Aws\Credentials(SNS_REGION);
-                $sns = new \Kyte\Aws\Sns($credential, SNS_QUEUE_SITE_MANAGEMENT);
-                $sns->publish([
-                    'action' => 'cf_invalidate',
-                    'site_id' => $r['site']['id'],
-                    'cf_id' => $r['site']['cfDistributionId'],
-                    'cf_invalidation_paths' => $invalidationPaths,
-                    'caller_id' => time(),
-                ]);
-            } else {
-                // invalidate CF
-                $app = new \Kyte\Core\ModelObject(Application);
-                $app->retrieve('id', $r['site']['application']['id']);
-                $credential = new \Kyte\Aws\Credentials($r['site']['region'], $app->aws_public_key, $app->aws_private_key);
-                $cf = new \Kyte\Aws\CloudFront($credential);
-                $cf->createInvalidation($r['site']['cfDistributionId'], $invalidationPaths);
-            }
+            // invalidate CF
+            $app = new \Kyte\Core\ModelObject(Application);
+            $app->retrieve('id', $r['site']['application']['id']);
+            $credential = new \Kyte\Aws\Credentials($r['site']['region'], $app->aws_public_key, $app->aws_private_key);
+            $cf = new \Kyte\Aws\CloudFront($credential);
+            $cf->createInvalidation($r['site']['cfDistributionId'], $invalidationPaths);
         } catch (\Throwable $e) {
             error_log("CloudFront invalidation failed (best-effort): " . $e->getMessage());
         }
@@ -691,24 +679,12 @@ class KyteScriptController extends ModelController
         // Best-effort: content is already published; a failed CloudFront
         // invalidation must not fail the request. Log and continue.
         try {
-            if (KYTE_USE_SNS) {
-                $credential = new \Kyte\Aws\Credentials(SNS_REGION);
-                $sns = new \Kyte\Aws\Sns($credential, SNS_QUEUE_SITE_MANAGEMENT);
-                $sns->publish([
-                    'action' => 'cf_invalidate',
-                    'site_id' => $d['site']['id'],
-                    'cf_id' => $d['site']['cfDistributionId'],
-                    'cf_invalidation_paths' => $invalidationPaths,
-                    'caller_id' => time(),
-                ]);
-            } else {
-                // invalidate CF
-                $app = new \Kyte\Core\ModelObject(Application);
-                $app->retrieve('id', $d['site']['application']['id']);
-                $credential = new \Kyte\Aws\Credentials($d['site']['region'], $app->aws_public_key, $app->aws_private_key);
-                $cf = new \Kyte\Aws\CloudFront($credential);
-                $cf->createInvalidation($d['site']['cfDistributionId'], $invalidationPaths);
-            }
+            // invalidate CF
+            $app = new \Kyte\Core\ModelObject(Application);
+            $app->retrieve('id', $d['site']['application']['id']);
+            $credential = new \Kyte\Aws\Credentials($d['site']['region'], $app->aws_public_key, $app->aws_private_key);
+            $cf = new \Kyte\Aws\CloudFront($credential);
+            $cf->createInvalidation($d['site']['cfDistributionId'], $invalidationPaths);
         } catch (\Throwable $e) {
             error_log("CloudFront invalidation failed (best-effort): " . $e->getMessage());
         }

--- a/src/Mvc/Controller/KyteShipyardUpdateController.php
+++ b/src/Mvc/Controller/KyteShipyardUpdateController.php
@@ -2,10 +2,35 @@
 
 namespace Kyte\Mvc\Controller;
 
+use Kyte\Core\DBI;
+
+/**
+ * Enqueues an update of the install's Kyte Shipyard dashboard to the latest
+ * published build. The heavy lifting (download/extract/upload/CloudFront
+ * invalidate) runs out-of-band in ShipyardUpdateWorker (a cron job) — NOT in this
+ * request — because it routinely exceeds the ~100s Cloudflare non-enterprise
+ * request ceiling (and ALB idle timeouts) on a real build. See KYTE-#201.
+ *
+ * Flow of `new`:
+ *   1. Validate input + Shipyard config.
+ *   2. Fast inline CDN version check (~100ms): if already current, return
+ *      "up to date" immediately — no row, no worker.
+ *   3. Request dedup: if a pending/running KyteShipyardUpdate already exists,
+ *      return it instead of enqueueing a duplicate.
+ *   4. Otherwise create a KyteShipyardUpdate row (status=pending) and return it.
+ *      The dashboard polls GET on this model (by id) for live status.
+ *
+ * Previously this published `current_version` to SNS_KYTE_SHIPYARD_UPDATE and the
+ * kyte-lambda-update-shipyard Lambda did the work (with two prod bugs — see
+ * ShipyardUpdateWorker). The SNS topic + Lambda are decommissioned in the final
+ * #201 step.
+ */
 class KyteShipyardUpdateController extends ModelController
 {
+    private const CHANGELOG_URL = 'https://cdn.keyqcloud.com/kyte/shipyard/archive/CHANGELOG.md';
+
     public function hook_init() {
-        $this->allowableActions = ['new'];
+        $this->allowableActions = ['new', 'get'];
     }
 
     public function new($data)
@@ -13,20 +38,102 @@ class KyteShipyardUpdateController extends ModelController
         if (!in_array('new', $this->allowableActions)) {
             return;
         }
-    
+
         if (!isset($data['current_version'])) {
             throw new \Exception('Missing current_version');
         }
+        if (!defined('KYTE_SHIPYARD_S3') || !defined('KYTE_SHIPYARD_CF') || !KYTE_SHIPYARD_S3 || !KYTE_SHIPYARD_CF) {
+            throw new \Exception('Shipyard update is not configured: define KYTE_SHIPYARD_S3 and KYTE_SHIPYARD_CF in config.');
+        }
 
-        $credential = new \Kyte\Aws\Credentials(SNS_REGION);
-        $sns = new \Kyte\Aws\Sns($credential, SNS_KYTE_SHIPYARD_UPDATE);
+        $currentVersion = $data['current_version'];
 
-        // queue creation of s3 bucket for static web app
-        $sns->publish([
-            'current_version' => $data['current_version'],
-        ]);
+        // Cheap, synchronous: only enqueue heavy work when actually behind.
+        $latestVersion = $this->getLatestVersion();
+        if ($latestVersion !== null && $latestVersion === $currentVersion) {
+            $this->response['data'] = [[
+                'updated'         => false,
+                'status'          => 'up_to_date',
+                'current_version' => $currentVersion,
+                'latest_version'  => $latestVersion,
+                'message'         => "Shipyard is up to date ({$currentVersion}).",
+            ]];
+            return;
+        }
 
-        $this->response['data'] = [$data['current_version']];
+        // Request dedup (install-wide; one Shipyard per install): don't queue a
+        // second update while one is already in flight. Execution dedup is the
+        // worker's job (lease lock + guarded pending->running claim).
+        $inflight = DBI::prepared_query(
+            "SELECT id, status, requested_version FROM KyteShipyardUpdate WHERE status IN ('pending','running') AND deleted = 0 ORDER BY id DESC LIMIT 1",
+            '',
+            []
+        );
+        if (!empty($inflight)) {
+            $this->response['data'] = [[
+                'updated'        => false,
+                'status'         => $inflight[0]['status'],
+                'id'             => (int) $inflight[0]['id'],
+                'latest_version' => $latestVersion,
+                'message'        => 'A Shipyard update is already in progress.',
+            ]];
+            return;
+        }
+
+        // Enqueue. Mirror ModelController::new's account/audit stamping since we
+        // build the row directly rather than delegating to the base action.
+        $row = [
+            'current_version'   => $currentVersion,
+            'requested_version' => $latestVersion,
+            'status'            => 'pending',
+            'message'           => 'Queued for the Shipyard update worker.',
+        ];
+        if ($this->requireAccount && isset($this->api->account->id)) {
+            $row['kyte_account'] = $this->api->account->id;
+        }
+        if (isset($this->api->user->id)) {
+            $row['created_by'] = $this->api->user->id;
+        }
+
+        $obj = new \Kyte\Core\ModelObject(KyteShipyardUpdate);
+        if (!$obj->create($row)) {
+            throw new \Exception('Failed to queue Shipyard update.');
+        }
+
+        $ret = $this->getObject($obj);
+        $ret['latest_version'] = $latestVersion;
+        $ret['message']        = "Shipyard update to {$latestVersion} queued.";
+        $this->response['data'] = [$ret];
     }
-    
+
+    /**
+     * Fetch the CDN changelog and return the first `## X.Y.Z` version, or null.
+     * Best-effort: on failure we return null and let the request enqueue anyway
+     * (the worker re-checks authoritatively before deploying).
+     */
+    private function getLatestVersion(): ?string
+    {
+        $ch = curl_init(self::CHANGELOG_URL);
+        if ($ch === false) {
+            return null;
+        }
+        curl_setopt_array($ch, [
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_FOLLOWLOCATION => true,
+            CURLOPT_TIMEOUT        => 15,
+            CURLOPT_CONNECTTIMEOUT => 10,
+        ]);
+        $body   = curl_exec($ch);
+        $status = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        curl_close($ch);
+
+        if ($body === false || $status < 200 || $status >= 300) {
+            error_log("Shipyard update: changelog version check failed (status {$status}).");
+            return null;
+        }
+        if (preg_match('/##\s*(\d+\.\d+\.\d+)/', $body, $m)) {
+            return $m[1];
+        }
+        return null;
+    }
 }

--- a/src/Mvc/Controller/NavigationController.php
+++ b/src/Mvc/Controller/NavigationController.php
@@ -71,21 +71,9 @@ class NavigationController extends ModelController
                 $invalidationPaths = ['/*'];
                 // Best-effort: content already in S3; a failed invalidation must not fail the request.
                 try {
-                    if (KYTE_USE_SNS) {
-                        $credential = new \Kyte\Aws\Credentials(SNS_REGION);
-                        $sns = new \Kyte\Aws\Sns($credential, SNS_QUEUE_SITE_MANAGEMENT);
-                        $sns->publish([
-                            'action' => 'cf_invalidate',
-                            'site_id' => $nav['site']['id'],
-                            'cf_id' => $nav['site']['cfDistributionId'],
-                            'cf_invalidation_paths' => $invalidationPaths,
-                            'caller_id' => time(),
-                        ]);
-                    } else {
-                        // invalidate CF
-                        $cf = new \Kyte\Aws\CloudFront($credential);
-                        $cf->createInvalidation($nav['site']['cfDistributionId'], $invalidationPaths);
-                    }
+                    // invalidate CF
+                    $cf = new \Kyte\Aws\CloudFront($credential);
+                    $cf->createInvalidation($nav['site']['cfDistributionId'], $invalidationPaths);
                 } catch (\Throwable $e) {
                     error_log("CloudFront invalidation failed (best-effort): " . $e->getMessage());
                 }

--- a/src/Mvc/Controller/SideNavController.php
+++ b/src/Mvc/Controller/SideNavController.php
@@ -71,21 +71,9 @@ class SideNavController extends ModelController
                 $invalidationPaths = ['/*'];
                 // Best-effort: content already in S3; a failed invalidation must not fail the request.
                 try {
-                    if (KYTE_USE_SNS) {
-                        $credential = new \Kyte\Aws\Credentials(SNS_REGION);
-                        $sns = new \Kyte\Aws\Sns($credential, SNS_QUEUE_SITE_MANAGEMENT);
-                        $sns->publish([
-                            'action' => 'cf_invalidate',
-                            'site_id' => $nav['site']['id'],
-                            'cf_id' => $nav['site']['cfDistributionId'],
-                            'cf_invalidation_paths' => $invalidationPaths,
-                            'caller_id' => time(),
-                        ]);
-                    } else {
-                        // invalidate CF
-                        $cf = new \Kyte\Aws\CloudFront($credential);
-                        $cf->createInvalidation($nav['site']['cfDistributionId'], $invalidationPaths);
-                    }
+                    // invalidate CF
+                    $cf = new \Kyte\Aws\CloudFront($credential);
+                    $cf->createInvalidation($nav['site']['cfDistributionId'], $invalidationPaths);
                 } catch (\Throwable $e) {
                     error_log("CloudFront invalidation failed (best-effort): " . $e->getMessage());
                 }

--- a/src/Mvc/Model/KyteShipyardUpdate.php
+++ b/src/Mvc/Model/KyteShipyardUpdate.php
@@ -1,0 +1,144 @@
+<?php
+
+/**
+ * KyteShipyardUpdate
+ *
+ * Tracks a request to update the install's Kyte Shipyard dashboard to the latest
+ * published build, and its outcome. The dashboard enqueues a row (status=pending)
+ * via KyteShipyardUpdateController; the ShipyardUpdateWorker cron job claims it
+ * (pending -> running), does the heavy download/extract/upload/invalidate work
+ * out-of-band (so a Cloudflare/ALB request timeout can't kill it), and writes the
+ * terminal status (complete/failed). See KYTE-#201.
+ */
+
+$KyteShipyardUpdate = [
+	'name' => 'KyteShipyardUpdate',
+	'struct' => [
+		// Version the dashboard reported running when the update was requested.
+		'current_version' => [
+			'type'		=> 's',
+			'required'	=> false,
+			'size'		=> 20,
+		],
+
+		// Version we intend to deploy (latest from the CDN changelog at request time).
+		'requested_version' => [
+			'type'		=> 's',
+			'required'	=> false,
+			'size'		=> 20,
+		],
+
+		// Version last successfully published by the worker.
+		'deployed_version' => [
+			'type'		=> 's',
+			'required'	=> false,
+			'size'		=> 20,
+		],
+
+		// pending | running | complete | failed
+		'status' => [
+			'type'		=> 's',
+			'required'	=> false,
+			'size'		=> 20,
+			'default'	=> 'pending',
+		],
+
+		// Human-readable result or error detail surfaced to the dashboard.
+		'message' => [
+			'type'		=> 't',
+			'required'	=> false,
+		],
+
+		'files_uploaded' => [
+			'type'		=> 'i',
+			'required'	=> false,
+			'unsigned'	=> true,
+			'default'	=> 0,
+		],
+
+		'files_failed' => [
+			'type'		=> 'i',
+			'required'	=> false,
+			'unsigned'	=> true,
+			'default'	=> 0,
+		],
+
+		'cloudfront_invalidated' => [
+			'type'		=> 'i',
+			'required'	=> false,
+			'size'		=> 1,
+			'unsigned'	=> true,
+			'default'	=> 0,
+		],
+
+		// Unix timestamps bracketing the worker run.
+		'started_at' => [
+			'type'		=> 'i',
+			'required'	=> false,
+			'unsigned'	=> true,
+		],
+
+		'finished_at' => [
+			'type'		=> 'i',
+			'required'	=> false,
+			'unsigned'	=> true,
+		],
+
+		// Framework attributes
+		'kyte_account' => [
+			'type'		=> 'i',
+			'required'	=> true,
+			'unsigned'	=> true,
+			'fk'		=> [
+				'model'	=> 'KyteAccount',
+				'field'	=> 'id',
+			],
+		],
+
+		// audit attributes
+		'created_by'		=> [
+			'type'		=> 'i',
+			'required'	=> false,
+			'date'		=> false,
+		],
+
+		'date_created'		=> [
+			'type'		=> 'i',
+			'required'	=> false,
+			'date'		=> true,
+		],
+
+		'modified_by'		=> [
+			'type'		=> 'i',
+			'required'	=> false,
+			'date'		=> false,
+		],
+
+		'date_modified'		=> [
+			'type'		=> 'i',
+			'required'	=> false,
+			'date'		=> true,
+		],
+
+		'deleted_by'		=> [
+			'type'		=> 'i',
+			'required'	=> false,
+			'date'		=> false,
+		],
+
+		'date_deleted'		=> [
+			'type'		=> 'i',
+			'required'	=> false,
+			'date'		=> true,
+		],
+
+		'deleted'	=> [
+			'type'		=> 'i',
+			'required'	=> false,
+			'size'		=> 1,
+			'unsigned'	=> true,
+			'default'	=> 0,
+			'date'		=> false,
+		],
+	],
+];


### PR DESCRIPTION
## Summary (KYTE-#201, target v4.12.0)

Continues the Lambda→cron migration. Three changes, all on this branch:

### 1. Remove `KYTE_USE_SNS` + dead SNS invalidation branches (`fd95685`)
Direct CloudFront invalidation (shipped + verified in 4.11.1) is now the only path. Dropped the `if (KYTE_USE_SNS) {…} else {…}` fork at all 10 invalidation sites, keeping the direct `Kyte\Aws\CloudFront::createInvalidation()` call in its existing best-effort try/catch. Removed the flag from `Api::$defaultEnvironmentConstants`, `sample-config.php`, and docs. Behavior-neutral (installs already run `KYTE_USE_SNS=false`). Kept `SNS_REGION`/`SNS_QUEUE_SITE_MANAGEMENT` + `Kyte\Aws\Sns` for site-provisioning (#3).

### 2. Shipyard self-update: Lambda → cron worker (`95a7103`)
Replaces the SNS → `kyte-lambda-update-shipyard` Lambda, which had two prod bugs (`boto3 ContentType=None` upload failures on `.map`/dir entries; `NoSuchDistribution` on a stale-env-var distribution → stale dashboard). The work now runs **out-of-band in a cron worker** because download/extract/upload/invalidate exceeds the ~100s Cloudflare non-enterprise request ceiling (and ALB idle timeouts) — a sync controller action would 524 on Cloudflare-fronted installs.

- New `KyteShipyardUpdate` model + `migrations/4.12.0_shipyard_update.sql` (status/version tracking).
- `KyteShipyardUpdateController::new` does a fast inline CDN version check, returns "up to date" immediately when current, else enqueues a `pending` row. Polled via `GET`.
- `ShipyardUpdateWorker` (`CronJobBase`, 60s) claims the oldest pending row, uploads via `S3::write()` with explicit per-extension Content-Type (unknown like `.map` omitted, not crashing — fixes bug #1), invalidates `KYTE_SHIPYARD_CF` from config (fixes bug #2). `heartbeat()` during uploads.
- Idempotency: controller request-dedup (no enqueue while pending/running) + worker execution-dedup (`allow_concurrent=0` lease lock + guarded `pending→running` claim on `affected_rows()==1`).
- New config: `KYTE_SHIPYARD_S3`, `KYTE_SHIPYARD_CF`, optional `KYTE_SHIPYARD_REGION` (default `us-east-1`). New dependency: `ext-zip`. `bin/register-shipyard-update-job.php` registers the job.

### 3. Per-app DB connections use SSL + dbappconnect routing fix (folded in)
`DBI::connectApp()` now connects via SSL (`ssl_set()` + `MYSQLI_CLIENT_SSL`) when `KYTE_DB_CA_BUNDLE` is defined, mirroring `connect()` — fixes apps failing on an SSL-required DB (`require_secure_transport=ON`). `Api::dbappconnect()` routing guard now compares the app statics (not main) and `closeApp()`s on app switch. Removed dead `dbInitApp()`.

## Verification
- **PHPStan level 1 clean** + `php -l` clean on all new files.
- **dev19 E2E (2026-06-29):** installed the branch, ran the migration, configured (`KYTE_SHIPYARD_REGION=us-east-2` — bucket/dist are Ohio), registered the job. Worker uploaded **168 files, 0 failed, CloudFront invalidated, deployed 2.3.0**; daemon production path confirmed; no-op branch confirmed. Manually verified in AWS console (S3 overwritten, invalidation completed) and the live Shipyard shows the correct version.
- phpunit runs here in CI (needs mysqli + DB).

## Per-install deploy order (important)
composer update → run `migrations/4.12.0_shipyard_update.sql` → set `KYTE_SHIPYARD_S3`/`KYTE_SHIPYARD_CF`(/`REGION`) in `config.php` (pull values from the existing Lambda's env) → `php bin/register-shipyard-update-job.php` → **`systemctl restart kyte-cron-worker`** (daemon reads config once at boot) → reload php-fpm/httpd.

Lambdas stay dormant until the final #201 decommission step (after #3, site-provisioning).

🤖 Generated with [Claude Code](https://claude.com/claude-code)