### PR TITLE
KYTE-#201 #3: site provisioning Lambda → cron worker (v4.13.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+## 4.13.0
+
+### Migration: site provisioning moved from Lambda into a cron worker — KYTE-#201
+
+`KyteSiteController` published S3/CloudFront/ACM actions to `SNS_QUEUE_SITE_MANAGEMENT` → the `kyte-lambda-site-management` self-chaining state machine did the work, writing back to the DB via the `kyte-lambda-database-transaction` Lambda. Both Lambdas are replaced by a cron worker that writes the DB directly. Completes the #201 migration off SNS/Lambda (after #1 + #2 in 4.12.0).
+
+- **`SiteProvisioningWorker`** (`src/Cron/SiteProvisioningWorker.php`, `CronJobBase`, interval 30s) scans `KyteSite` rows in `creating`/`deleting` and advances each one actionable step per tick. **Sub-state is inferred from the populated `s3*`/`cf*` columns** (no separate state machine), and every AWS op is **idempotent** so a tick is safe to re-run:
+  - **CREATE:** website bucket (create [us-east-1-aware] → drop public-access-block → public-read policy → website config) → media bucket (CORS instead) → website CloudFront → media CloudFront (each distribution id persisted the instant it's created, since `createDistribution` isn't idempotent) → poll both until `Deployed` → `status=active`.
+  - **DELETE:** empty+delete each bucket → disable+delete each distribution (polled across ticks) → delete ACM certs + `Domain`/`SAN` rows (after the distributions are gone — a cert can't be deleted while attached) → `status=deleted`.
+  - CloudFront create/delete take minutes, so deployment is **polled across ticks** with `heartbeat()` — never a blocking sleep. A site that errors `MAX_ATTEMPTS` times flips to `status=failed` with `provisioning_message` instead of looping.
+- **`KyteSiteController`** `new`/`delete` no longer publish to SNS — they just set `status=creating`/`deleting` (+ the existing content-record cleanup) and let the worker take over. Domain/cert teardown moved to the worker (ordering depends on the distribution being deleted first).
+- **`Kyte\Aws` wrapper fixes:** `S3::createBucket` no longer sends a `LocationConstraint` for `us-east-1` (it was failing there) and is idempotent on `BucketAlreadyOwnedByYou`; **new `S3::emptyBucket()`** (paginated, version-aware) so `deleteBucket()` works; `CloudFront` now applies `DefaultTTL` (86400) and the worker sets `MinTTL`=3600 for parity with the old Lambda; **new `CloudFront::isEnabled()`**.
+- **New:** `migrations/4.13.0_site_provisioning.sql` (adds `KyteSite.provisioning_message` + `provisioning_attempts`), `bin/register-site-provisioning-job.php`.
+- **Unlocks** native MCP `create_site`/`create_app`. After this soaks, all 3 Lambdas + `SNS_QUEUE_SITE_MANAGEMENT` can be decommissioned.
+
 ## 4.12.0
 
 ### Cleanup: remove `KYTE_USE_SNS` flag + dead SNS invalidation branches — KYTE-#201

--- a/bin/register-site-provisioning-job.php
+++ b/bin/register-site-provisioning-job.php
@@ -1,0 +1,108 @@
+#!/usr/bin/env php
+<?php
+/**
+ * Register Site Provisioning Cron Job
+ *
+ * Registers SiteProvisioningWorker in the CronJob table so the cron worker daemon
+ * provisions/deprovisions KyteSite AWS resources (KYTE-#201 #3). Replaces the
+ * kyte-lambda-site-management + kyte-lambda-database-transaction Lambdas.
+ *
+ * Prereqs:
+ *   - Run migrations/4.13.0_site_provisioning.sql (KyteSite provisioning columns).
+ *   - kyte-cron-worker daemon running (created during the v4.12.0 rollout).
+ *
+ * Usage:
+ *   php bin/register-site-provisioning-job.php
+ *
+ * Registered with interval=30s, allow_concurrent=0 (lease lock → single runner),
+ * timeout=600s (heartbeat extends it across the multi-minute CloudFront polls).
+ */
+
+require_once __DIR__ . '/bootstrap.php';
+
+use Kyte\Core\DBI;
+
+echo "============================================\n";
+echo "Site Provisioning Job Registration\n";
+echo "============================================\n\n";
+
+try {
+	$jobFile = dirname(__DIR__) . '/src/Cron/SiteProvisioningWorker.php';
+
+	if (!file_exists($jobFile)) {
+		throw new \Exception("Job file not found: {$jobFile}");
+	}
+
+	$code = file_get_contents($jobFile);
+	echo "✓ Job code loaded (" . strlen($code) . " bytes)\n";
+
+	$compressed = bzcompress($code);
+	echo "✓ Code compressed (" . strlen($compressed) . " bytes)\n";
+
+	$jobName        = 'SiteProvisioningWorker';
+	$jobDescription = 'Provisions/deprovisions KyteSite AWS resources (2 S3 buckets + 2 CloudFront distributions per site, + ACM certs on delete) by advancing creating/deleting sites each tick. Replaces kyte-lambda-site-management and kyte-lambda-database-transaction.';
+
+	$sql = "SELECT id FROM CronJob WHERE name = ? AND application IS NULL AND (kyte_account = 0 OR kyte_account = 1) AND deleted = 0";
+	$existing = DBI::prepared_query($sql, 's', [$jobName]);
+
+	if (!empty($existing)) {
+		echo "\n⚠ Job already exists (ID: {$existing[0]['id']})\n";
+		echo "Would you like to update it? (y/n): ";
+		$handle = fopen("php://stdin", "r");
+		$response = trim(fgets($handle));
+		fclose($handle);
+
+		if (strtolower($response) !== 'y') {
+			echo "Cancelled.\n";
+			exit(0);
+		}
+
+		$sql = "
+			UPDATE CronJob
+			SET code = ?,
+				description = ?,
+				kyte_account = 0,
+				date_modified = UNIX_TIMESTAMP()
+			WHERE id = ?
+		";
+		DBI::prepared_query($sql, 'ssi', [$compressed, $jobDescription, $existing[0]['id']]);
+		echo "✓ Job updated (ID: {$existing[0]['id']})\n";
+
+	} else {
+		// interval=30s, enabled, timeout=600s, allow_concurrent=0, low retries
+		// (per-site failures are recorded on the KyteSite row, not retried as a job).
+		$sql = "
+			INSERT INTO CronJob (
+				name, description, code, schedule_type, interval_seconds,
+				enabled, timeout_seconds, allow_concurrent, max_retries,
+				retry_strategy, retry_delay_seconds, notify_on_failure,
+				notify_after_failures, notify_on_dead_letter,
+				kyte_account, application, date_created
+			) VALUES (
+				?, ?, ?, 'interval', 30,
+				1, 600, 0, 1,
+				'exponential', 60, 0,
+				3, 0,
+				0, NULL, UNIX_TIMESTAMP()
+			)
+		";
+		DBI::prepared_query($sql, 'sss', [$jobName, $jobDescription, $compressed]);
+
+		$jobId = DBI::insert_id();
+		echo "✓ Job created (ID: {$jobId})\n";
+	}
+
+	echo "\n============================================\n";
+	echo "Registration Complete!\n";
+	echo "============================================\n\n";
+
+	echo "The job runs every 30 seconds. Ensure the cron worker daemon is running:\n\n";
+	echo "  systemctl status kyte-cron-worker\n\n";
+	echo "Run migrations/4.13.0_site_provisioning.sql first if you haven't.\n";
+	echo "Manage the job in Kyte Shipyard: System > Cron Jobs\n\n";
+
+} catch (\Exception $e) {
+	echo "\n❌ ERROR: " . $e->getMessage() . "\n";
+	echo $e->getTraceAsString() . "\n";
+	exit(1);
+}

--- a/migrations/4.13.0_site_provisioning.sql
+++ b/migrations/4.13.0_site_provisioning.sql
@@ -1,0 +1,22 @@
+-- =========================================================================
+-- Kyte v4.13.0 - site-provisioning worker columns (KYTE-#201 #3)
+-- =========================================================================
+-- IMPORTANT: Backup your database before running this migration.
+--
+-- Adds two columns to KyteSite for the SiteProvisioningWorker cron job (which
+-- replaces kyte-lambda-site-management + kyte-lambda-database-transaction). The
+-- create/delete sub-state itself is inferred from the existing s3*/cf* columns;
+-- these are for surfacing failures to the dashboard and bounding retries:
+--   provisioning_message   - last error/status detail
+--   provisioning_attempts  - failed-tick counter; worker flips status='failed'
+--                            after a cap instead of looping forever.
+--
+-- ADDITIVE / migration-first / inert on older code. PascalCase table.
+--
+-- See src/Cron/SiteProvisioningWorker.php, src/Mvc/Model/KyteSite.php,
+-- docs/design/site-provisioning-cron-worker.md.
+-- =========================================================================
+
+ALTER TABLE `KyteSite`
+    ADD COLUMN `provisioning_message`  TEXT             DEFAULT NULL,
+    ADD COLUMN `provisioning_attempts` INT UNSIGNED NOT NULL DEFAULT 0;

--- a/src/Aws/CloudFront.php
+++ b/src/Aws/CloudFront.php
@@ -118,7 +118,7 @@ class CloudFront extends Client
         $this->AllowedMethods = ['GET', 'HEAD'];
         $this->AllowedCachedMethods = ['GET', 'HEAD'];
         $this->SmoothStreaming = false;
-        // $this->DefaultTTL = 86400;
+        $this->DefaultTTL = 86400;
         // $this->MaxTTL = 315360000;
         $this->Compress = true;
         // $this->FunctionAssociations;                   // [ 'EventType' => 'viewer-request|viewer-response|origin-request|origin-response', 'FunctionARN' => '<string>', ]
@@ -347,6 +347,12 @@ class CloudFront extends Client
         }
     }
 
+    // Whether the loaded distribution is currently enabled. Call getDistribution()
+    // first (it populates distributionConfig). Returns null if not loaded.
+    public function isEnabled() {
+        return isset($this->distributionConfig['Enabled']) ? (bool) $this->distributionConfig['Enabled'] : null;
+    }
+
     public function addOrigin(
         // $ConnectionAttempts,            // integer
         // $ConnectionTimeout,             // integer
@@ -466,6 +472,7 @@ class CloudFront extends Client
         ];
         $this->distributionConfig['DefaultCacheBehavior']['Compress'] = $this->Compress;
         $this->distributionConfig['DefaultCacheBehavior']['MinTTL'] = $this->MinTTL;
+        $this->distributionConfig['DefaultCacheBehavior']['DefaultTTL'] = $this->DefaultTTL;
         $this->distributionConfig['DefaultCacheBehavior']['TargetOriginId'] = $this->TargetOriginId;
         $this->distributionConfig['DefaultCacheBehavior']['ViewerProtocolPolicy'] = $this->ViewerProtocolPolicy;
         $this->distributionConfig['DefaultCacheBehavior']['ForwardedValues'] = [

--- a/src/Aws/CloudFront.php
+++ b/src/Aws/CloudFront.php
@@ -303,9 +303,14 @@ class CloudFront extends Client
         try {
             $distributionId = $this->Id ? $this->Id : $distributionId;
 
-            $result = $this->client->deleteDistribution([
-                'Id' => $distributionId
-            ]);
+            $params = ['Id' => $distributionId];
+            // DeleteDistribution REQUIRES the current ETag as IfMatch (just like
+            // updateDistribution); getDistribution() populates $this->etag. Without
+            // it AWS rejects the call with InvalidIfMatchVersion.
+            if (!empty($this->etag)) {
+                $params['IfMatch'] = $this->etag;
+            }
+            $result = $this->client->deleteDistribution($params);
 
             $this->Id = null;
             $this->Arn = null;

--- a/src/Aws/S3.php
+++ b/src/Aws/S3.php
@@ -24,18 +24,30 @@ class S3 extends Client
     // create bucket
     public function createBucket() {
         try {
-            $this->client->createBucket([
+            $params = [
                 // 'ACL' => $this->acl, // 'private|public-read|public-read-write|authenticated-read'
                 'Bucket' => $this->bucket, // REQUIRED
-                'CreateBucketConfiguration' => [
-                    'LocationConstraint' => $this->credentials->getRegion() //'ap-northeast-1|ap-southeast-2|ap-southeast-1|cn-north-1|eu-central-1|eu-west-1|us-east-1|us-west-1|us-west-2|sa-east-1'
-                ]
-            ]);
+            ];
+            // us-east-1 is the S3 default region and MUST NOT carry a
+            // LocationConstraint (S3 rejects it with InvalidLocationConstraint);
+            // every other region requires one.
+            if ($this->credentials->getRegion() !== 'us-east-1') {
+                $params['CreateBucketConfiguration'] = [
+                    'LocationConstraint' => $this->credentials->getRegion(),
+                ];
+            }
+
+            $this->client->createBucket($params);
 
             return true;
-        } catch (\AwsException $e) {
-			throw $e;
-		}
+        } catch (\Aws\Exception\AwsException $e) {
+            // Idempotent: if we already own this bucket, treat as success so the
+            // provisioning worker can safely re-run the create step on retry.
+            if ($e->getAwsErrorCode() === 'BucketAlreadyOwnedByYou') {
+                return true;
+            }
+            throw $e;
+        }
 
         // if ($context) {
         //     $context = stream_context_create($context);
@@ -185,6 +197,46 @@ class S3 extends Client
         }
 
         return true;
+    }
+
+    // empty a bucket of all objects (and versions/delete-markers) so it can be
+    // deleted. Paginated; idempotent if the bucket is already gone. Used by the
+    // site-provisioning worker's delete flow (replaces the Lambda's boto3 purge).
+    public function emptyBucket() {
+        if (!$this->bucket) {
+            throw new \Exception('bucket must be defined');
+        }
+        try {
+            // ListObjectVersions covers both versioned and unversioned buckets
+            // (unversioned objects come back under 'Versions' with VersionId 'null').
+            $paginator = $this->client->getPaginator('ListObjectVersions', [
+                'Bucket' => $this->bucket,
+            ]);
+            foreach ($paginator as $page) {
+                $items = array_merge(
+                    $page['Versions'] ?? [],
+                    $page['DeleteMarkers'] ?? []
+                );
+                if (empty($items)) {
+                    continue;
+                }
+                $this->client->deleteObjects([
+                    'Bucket' => $this->bucket,
+                    'Delete' => [
+                        'Objects' => array_map(function ($o) {
+                            return ['Key' => $o['Key'], 'VersionId' => $o['VersionId']];
+                        }, $items),
+                        'Quiet' => true,
+                    ],
+                ]);
+            }
+            return true;
+        } catch (\Aws\Exception\AwsException $e) {
+            if ($e->getAwsErrorCode() === 'NoSuchBucket') {
+                return true; // already gone — idempotent
+            }
+            throw $e;
+        }
     }
 
     // delete bucket

--- a/src/Cron/SiteProvisioningWorker.php
+++ b/src/Cron/SiteProvisioningWorker.php
@@ -57,6 +57,12 @@ class SiteProvisioningWorker extends CronJobBase
                 } else {
                     $summary[$id] = $this->advanceDelete($credential, $site);
                 }
+                // A successful step clears any prior transient-error state so the
+                // attempts counter doesn't creep toward the give-up cap and the
+                // dashboard doesn't show a stale error.
+                if ((int) $site['provisioning_attempts'] > 0) {
+                    $this->updateSite($id, ['provisioning_attempts' => 0, 'provisioning_message' => null]);
+                }
             } catch (\Throwable $e) {
                 $this->recordFailure($id, (int) $site['provisioning_attempts'], $site['status'], $e->getMessage());
                 $summary[$id] = 'error: ' . $e->getMessage();

--- a/src/Cron/SiteProvisioningWorker.php
+++ b/src/Cron/SiteProvisioningWorker.php
@@ -1,0 +1,337 @@
+<?php
+
+namespace Kyte\Cron;
+
+use Kyte\Core\CronJobBase;
+use Kyte\Core\DBI;
+use Kyte\Core\ModelObject;
+
+/**
+ * SiteProvisioningWorker
+ *
+ * Provisions and tears down KyteSite AWS resources (2 S3 buckets + 2 CloudFront
+ * distributions per site, + ACM certs on delete), replacing the SNS-driven
+ * kyte-lambda-site-management state machine and the kyte-lambda-database-transaction
+ * DB writer (the worker writes the DB directly). KYTE-#201 #3.
+ *
+ * Tick model (interval ~20-30s, allow_concurrent=0): each tick scans KyteSite rows
+ * in 'creating'/'deleting' and advances each ONE actionable step. Sub-state is
+ * inferred from which s3/cf columns are populated, and every AWS op is idempotent
+ * (create_bucket tolerates already-owned; CF ids are persisted the instant the
+ * distribution is created; bucket/CF teardown tolerates already-gone). CloudFront
+ * create/delete take minutes, so deployment is POLLED across ticks (status stays
+ * creating/deleting) with heartbeat() — never a blocking sleep in one execute().
+ *
+ * Failure handling: a per-site exception bumps provisioning_attempts + records
+ * provisioning_message; after MAX_ATTEMPTS the site flips to 'failed' rather than
+ * looping forever (the dashboard shows the message).
+ */
+class SiteProvisioningWorker extends CronJobBase
+{
+    /** ~ MAX_ATTEMPTS * interval should comfortably exceed CF deploy time (5-15 min). */
+    private const MAX_ATTEMPTS = 120;
+
+    public function execute()
+    {
+        $sites = DBI::prepared_query(
+            "SELECT * FROM KyteSite WHERE status IN ('creating','deleting') AND deleted = 0 ORDER BY date_modified ASC, id ASC",
+            '',
+            []
+        );
+        if (empty($sites)) {
+            return json_encode(['processed' => 0, 'message' => 'No sites provisioning/deprovisioning.']);
+        }
+
+        $summary = [];
+        foreach ($sites as $i => $site) {
+            $id = (int) $site['id'];
+            try {
+                $app = new ModelObject(Application);
+                if (!$app->retrieve('id', $site['application'])) {
+                    throw new \Exception("Application #{$site['application']} not found for site #{$id}.");
+                }
+                $credential = new \Kyte\Aws\Credentials($site['region'], $app->aws_public_key, $app->aws_private_key);
+
+                if ($site['status'] === 'creating') {
+                    $summary[$id] = $this->advanceCreate($credential, $site);
+                } else {
+                    $summary[$id] = $this->advanceDelete($credential, $site);
+                }
+            } catch (\Throwable $e) {
+                $this->recordFailure($id, (int) $site['provisioning_attempts'], $site['status'], $e->getMessage());
+                $summary[$id] = 'error: ' . $e->getMessage();
+                $this->log("Site #{$id} step failed: " . $e->getMessage());
+            }
+            $this->heartbeat();
+        }
+
+        return json_encode(['processed' => count($sites), 'sites' => $summary]);
+    }
+
+    /**
+     * Advance a 'creating' site one step. Per-resource guards make this safe to
+     * re-run every tick: each block runs only while its column is empty.
+     *
+     * @param array<string,mixed> $site
+     */
+    private function advanceCreate($credential, array $site): string
+    {
+        $id     = (int) $site['id'];
+        $region = $site['region'];
+
+        // 1. Website bucket: create + configure, then persist s3BucketName (only
+        //    after full config, so a mid-way failure re-runs the whole block).
+        if (empty($site['s3BucketName'])) {
+            $bucket = $this->deriveBucketName($site['name'], false);
+            $this->setupBucket($credential, $bucket, true);
+            $this->updateSite($id, ['s3BucketName' => $bucket]);
+            return "website bucket created ({$bucket})";
+        }
+
+        // 2. Media bucket.
+        if (empty($site['s3MediaBucketName'])) {
+            $bucket = $this->deriveBucketName($site['name'], true);
+            $this->setupBucket($credential, $bucket, false);
+            $this->updateSite($id, ['s3MediaBucketName' => $bucket]);
+            return "media bucket created ({$bucket})";
+        }
+
+        // 3. Website CloudFront — persist the id IMMEDIATELY (create is not idempotent).
+        if (empty($site['cfDistributionId'])) {
+            $origin = \Kyte\Mvc\Controller\KyteSiteController::getWebsiteEndpoint($site['s3BucketName'], $region);
+            [$cfId, $cfDomain] = $this->createDistribution($credential, $site['s3BucketName'], $origin, $region, true);
+            $this->updateSite($id, ['cfDistributionId' => $cfId, 'cfDomain' => $cfDomain]);
+            return "website distribution created ({$cfId})";
+        }
+
+        // 4. Media CloudFront.
+        if (empty($site['cfMediaDistributionId'])) {
+            $origin = $site['s3MediaBucketName'] . '.s3.amazonaws.com';
+            [$cfId, $cfDomain] = $this->createDistribution($credential, $site['s3MediaBucketName'], $origin, $region, false);
+            $this->updateSite($id, ['cfMediaDistributionId' => $cfId, 'cfMediaDomain' => $cfDomain]);
+            return "media distribution created ({$cfId})";
+        }
+
+        // 5. Both distributions exist — poll until both Deployed, then activate.
+        if ($this->isDeployed($credential, $site['cfDistributionId']) &&
+            $this->isDeployed($credential, $site['cfMediaDistributionId'])) {
+            $this->updateSite($id, ['status' => 'active', 'provisioning_message' => null, 'provisioning_attempts' => 0]);
+            return 'active';
+        }
+        return 'awaiting CloudFront deployment';
+    }
+
+    /**
+     * Advance a 'deleting' site one step. Tears down media then website (bucket
+     * then its distribution), then ACM certs + Domain rows, then marks deleted.
+     *
+     * @param array<string,mixed> $site
+     */
+    private function advanceDelete($credential, array $site): string
+    {
+        $id = (int) $site['id'];
+
+        // 1/2. Media bucket + distribution.
+        if (!empty($site['s3MediaBucketName'])) {
+            $this->teardownBucket($credential, $site['s3MediaBucketName']);
+            $this->updateSite($id, ['s3MediaBucketName' => null]);
+            return 'media bucket deleted';
+        }
+        if (!empty($site['cfMediaDistributionId'])) {
+            if ($this->teardownDistribution($credential, $site['cfMediaDistributionId']) === 'deleted') {
+                $this->updateSite($id, ['cfMediaDistributionId' => null]);
+                return 'media distribution deleted';
+            }
+            return 'disabling/awaiting media distribution';
+        }
+
+        // 3/4. Website bucket + distribution.
+        if (!empty($site['s3BucketName'])) {
+            $this->teardownBucket($credential, $site['s3BucketName']);
+            $this->updateSite($id, ['s3BucketName' => null]);
+            return 'website bucket deleted';
+        }
+        if (!empty($site['cfDistributionId'])) {
+            if ($this->teardownDistribution($credential, $site['cfDistributionId']) === 'deleted') {
+                $this->updateSite($id, ['cfDistributionId' => null]);
+                return 'website distribution deleted';
+            }
+            return 'disabling/awaiting website distribution';
+        }
+
+        // 5. All AWS resources gone — delete ACM certs (now free of the distribution),
+        //    their Domain/SAN rows, then mark the site deleted.
+        $this->teardownDomains($credential, $id);
+        $this->updateSite($id, [
+            'status'       => 'deleted',
+            'deleted'      => 1,
+            'date_deleted' => time(),
+        ]);
+        return 'deleted';
+    }
+
+    /** name → bucket name, matching KyteSiteController's scheme (sans timestamp; the row already exists). */
+    private function deriveBucketName(string $name, bool $isMedia): string
+    {
+        $base = strtolower(preg_replace('/[^A-Za-z0-9_-]/', '-', $name));
+        // Keep the historical timestamp suffix shape so names stay unique per site.
+        return $isMedia ? $base . '-static-assets-' . time() : $base . '-' . time();
+    }
+
+    /** Create + fully configure a public-read S3 bucket (website or media). Idempotent. */
+    private function setupBucket($credential, string $bucket, bool $isWebsite): void
+    {
+        $s3 = new \Kyte\Aws\S3($credential, $bucket, 'public');
+        $s3->createBucket();                 // tolerates BucketAlreadyOwnedByYou
+        $s3->deletePublicAccessBlock();
+        $s3->enablePublicAccess();           // public-read GetObject policy
+        if ($isWebsite) {
+            $s3->createWebsite('index.html', 'error.html');
+        } else {
+            $s3->enableCors([[
+                'AllowedHeaders' => ['*'],
+                'AllowedMethods' => ['GET', 'POST'],
+                'AllowedOrigins' => ['*'],
+            ]]);
+        }
+    }
+
+    /**
+     * Create a CloudFront distribution mirroring the Lambda's config (OriginShield,
+     * http-only custom origin, redirect-to-https, compress, DefaultTTL 86400 / MinTTL 3600).
+     *
+     * @return array{0:string,1:string} [distributionId, domainName]
+     */
+    private function createDistribution($credential, string $bucket, string $origin, string $region, bool $isWebsite): array
+    {
+        $cf = new \Kyte\Aws\CloudFront($credential);
+        $cf->DefaultRootObject = $isWebsite ? 'index.html' : '';
+        $cf->Comment           = 'Created by Kyte for bucket ' . $bucket;
+        $cf->MinTTL            = 3600;
+        $cf->DefaultTTL        = 86400;
+        $cf->PriceClass        = 'PriceClass_All';
+        $cf->addOrigin($origin, $bucket, '', true, $region, false, 'http-only');
+        $cf->create();
+        return [$cf->Id, $cf->domainName];
+    }
+
+    /** True once the distribution is Deployed. */
+    private function isDeployed($credential, string $distributionId): bool
+    {
+        $cf = new \Kyte\Aws\CloudFront($credential, $distributionId);
+        $cf->getDistribution();
+        return $cf->status === 'Deployed';
+    }
+
+    /** Empty + delete a bucket. Idempotent (already-gone is success). */
+    private function teardownBucket($credential, string $bucket): void
+    {
+        $s3 = new \Kyte\Aws\S3($credential, $bucket, 'public');
+        $s3->emptyBucket();
+        try {
+            $s3->deleteBucket();
+        } catch (\Throwable $e) {
+            if (strpos($e->getMessage(), 'NoSuchBucket') === false) {
+                throw $e;
+            }
+        }
+    }
+
+    /**
+     * Disable then delete a distribution across ticks.
+     * @return string 'deleted' once gone, else 'pending' (disabling/deploying).
+     */
+    private function teardownDistribution($credential, string $distributionId): string
+    {
+        $cf = new \Kyte\Aws\CloudFront($credential, $distributionId);
+        try {
+            $cf->getDistribution();
+        } catch (\Throwable $e) {
+            if (strpos($e->getMessage(), 'NoSuchDistribution') !== false) {
+                return 'deleted'; // already gone
+            }
+            throw $e;
+        }
+
+        // Mid-update (InProgress) — wait for the next tick.
+        if ($cf->status !== 'Deployed') {
+            return 'pending';
+        }
+        // Still enabled — disable, then wait for it to redeploy disabled.
+        if ($cf->isEnabled()) {
+            $cf->disable();
+            return 'pending';
+        }
+        // Disabled + Deployed — safe to delete.
+        $cf->delete();
+        return 'deleted';
+    }
+
+    /** Delete the site's ACM certs (now detached) + their Domain/SAN rows. */
+    private function teardownDomains($credential, int $siteId): void
+    {
+        $domains = DBI::prepared_query(
+            "SELECT id, certificateArn FROM Domain WHERE site = ? AND deleted = 0",
+            'i',
+            [$siteId]
+        );
+        foreach ($domains as $domain) {
+            if (!empty($domain['certificateArn'])) {
+                try {
+                    $acm = new \Kyte\Aws\Acm($credential, $domain['certificateArn']);
+                    $acm->delete();
+                } catch (\Throwable $e) {
+                    $this->log("ACM delete failed for cert {$domain['certificateArn']} (site #{$siteId}): " . $e->getMessage());
+                }
+            }
+            $sans = new \Kyte\Core\Model(SubjectAlternativeName);
+            $sans->retrieve('domain', $domain['id']);
+            foreach ($sans->objects as $san) {
+                $san->delete();
+            }
+            $d = new ModelObject(Domain);
+            if ($d->retrieve('id', $domain['id'])) {
+                $d->delete();
+            }
+        }
+    }
+
+    private function recordFailure(int $id, int $attempts, string $status, string $message): void
+    {
+        $attempts++;
+        if ($attempts >= self::MAX_ATTEMPTS) {
+            $this->updateSite($id, [
+                'status'                => 'failed',
+                'provisioning_attempts' => $attempts,
+                'provisioning_message'  => "Gave up after {$attempts} attempts (was {$status}): " . $message,
+            ]);
+        } else {
+            $this->updateSite($id, [
+                'provisioning_attempts' => $attempts,
+                'provisioning_message'  => $message,
+            ]);
+        }
+    }
+
+    /**
+     * Direct KyteSite write (the database-transaction Lambda's job). Null values
+     * are bound as SQL NULL (used to clear cf/s3 columns during teardown).
+     *
+     * @param array<string,mixed> $fields
+     */
+    private function updateSite(int $id, array $fields): void
+    {
+        $sets  = [];
+        $types = '';
+        $vals  = [];
+        foreach ($fields as $col => $val) {
+            $sets[]  = "`{$col}` = ?";
+            $types  .= is_int($val) ? 'i' : 's';
+            $vals[]  = $val;
+        }
+        $sets[]  = 'date_modified = UNIX_TIMESTAMP()';
+        $types  .= 'i';
+        $vals[]  = $id;
+        DBI::prepared_query("UPDATE KyteSite SET " . implode(', ', $sets) . " WHERE id = ?", $types, $vals);
+    }
+}

--- a/src/Cron/SiteProvisioningWorker.php
+++ b/src/Cron/SiteProvisioningWorker.php
@@ -273,7 +273,12 @@ class SiteProvisioningWorker extends CronJobBase
         return 'deleted';
     }
 
-    /** Delete the site's ACM certs (now detached) + their Domain/SAN rows. */
+    /**
+     * Delete the site's ACM certs (now detached from the deleted distributions)
+     * and soft-delete their Domain/SAN rows. Uses raw SQL (table names) rather than
+     * model-name constants, which aren't reliably defined in the eval'd cron-worker
+     * context (they resolve to the worker's namespace and fall through).
+     */
     private function teardownDomains($credential, int $siteId): void
     {
         $domains = DBI::prepared_query(
@@ -287,18 +292,20 @@ class SiteProvisioningWorker extends CronJobBase
                     $acm = new \Kyte\Aws\Acm($credential, $domain['certificateArn']);
                     $acm->delete();
                 } catch (\Throwable $e) {
-                    $this->log("ACM delete failed for cert {$domain['certificateArn']} (site #{$siteId}): " . $e->getMessage());
+                    // Best-effort: a cert already gone (e.g. a prior tick) is fine.
+                    $this->log("ACM delete for cert {$domain['certificateArn']} (site #{$siteId}): " . $e->getMessage());
                 }
             }
-            $sans = new \Kyte\Core\Model(SubjectAlternativeName);
-            $sans->retrieve('domain', $domain['id']);
-            foreach ($sans->objects as $san) {
-                $san->delete();
-            }
-            $d = new ModelObject(Domain);
-            if ($d->retrieve('id', $domain['id'])) {
-                $d->delete();
-            }
+            DBI::prepared_query(
+                "UPDATE SubjectAlternativeName SET deleted = 1, date_deleted = UNIX_TIMESTAMP() WHERE domain = ? AND deleted = 0",
+                'i',
+                [$domain['id']]
+            );
+            DBI::prepared_query(
+                "UPDATE Domain SET deleted = 1, date_deleted = UNIX_TIMESTAMP() WHERE id = ?",
+                'i',
+                [$domain['id']]
+            );
         }
     }
 

--- a/src/Mvc/Controller/KyteSiteController.php
+++ b/src/Mvc/Controller/KyteSiteController.php
@@ -84,41 +84,11 @@ class KyteSiteController extends ModelController
                     throw new \Exception("Unknown region $region. Please check to make sure you specified a valid region for AWS S3.");
                 }
 
-                // create unique names for s3 buckets
-                $timestamp = time();
-                $bucketName = strtolower(preg_replace('/[^A-Za-z0-9_-]/', '-', $r['name']).'-'.$timestamp);
-                $s3MediaBucketName = strtolower(preg_replace('/[^A-Za-z0-9_-]/', '-', $r['name']).'-static-assets-'.$timestamp);
-
-                // TODO: endpoint url changes based on region!
-                // see: https://docs.aws.amazon.com/general/latest/gr/s3.html#s3_website_region_endpoints
-                $websiteOrigin = self::getWebsiteEndpoint($bucketName, $region);
-                // static content origin url
-                $staticContentOrigin = $s3MediaBucketName.'.s3.amazonaws.com';
-
-                $credential = new \Kyte\Aws\Credentials(SNS_REGION);
-                $sns = new \Kyte\Aws\Sns($credential, SNS_QUEUE_SITE_MANAGEMENT);
-
-                // queue creation of s3 bucket for static web app
-                $sns->publish([
-                    'action' => 's3_create',
-                    'region_name' => $region,
-                    'bucket_name' => $bucketName,
-                    'cf_origin' => $websiteOrigin,
-                    'site_id' => $o->id,
-                    'is_website' => true,
-                    'is_media' => false,
-                ]);
-
-                // queue creation of s3 bucket for static content
-                $sns->publish([
-                    'action' => 's3_create',
-                    'region_name' => $region,
-                    'bucket_name' => $s3MediaBucketName,
-                    'cf_origin' => $staticContentOrigin,
-                    'site_id' => $o->id,
-                    'is_website' => false,
-                    'is_media' => true,
-                ]);
+                // Provisioning (2 S3 buckets + 2 CloudFront distributions) is now
+                // handled out-of-band by SiteProvisioningWorker: it picks up the row
+                // while status='creating' (set in hook_preprocess) and derives the
+                // bucket names + origins itself. KYTE-#201 #3 — replaces the SNS
+                // publish to kyte-lambda-site-management.
                 break;
             
             default:
@@ -141,27 +111,11 @@ class KyteSiteController extends ModelController
             'date_modified' => time(),
         ]);
 
-        // add s3 static content bucket to deletion queue
-        $credential = new \Kyte\Aws\Credentials(SNS_REGION);
-        $sns = new \Kyte\Aws\Sns($credential, SNS_QUEUE_SITE_MANAGEMENT);
-        $sns->publish([
-            'action' => 's3_delete',
-            'region_name' => $o->region,
-            'bucket_name' => $o->s3MediaBucketName,
-            'site_id' => $o->id,
-            'cf_id' => $o->cfMediaDistributionId,
-        ]);
+        // AWS teardown (empty+delete both buckets, disable+delete both CloudFront
+        // distributions, then delete ACM certs) is now handled out-of-band by
+        // SiteProvisioningWorker, which picks up the row while status='deleting'.
+        // KYTE-#201 #3 — replaces the SNS publish to kyte-lambda-site-management.
 
-        // add s3 web app bucket to deletion queue
-        $params = [
-            'action' => 's3_delete',
-            'region_name' => $o->region,
-            'bucket_name' => $o->s3BucketName,
-            'site_id' => $o->id,
-            'cf_id' => $o->cfDistributionId,
-        ];
-        $sns->publish($params, $o->id);
-        
         // delete KytePage
         $objs = new \Kyte\Core\Model(KytePage);
         $objs->retrieve('site', $o->id);
@@ -229,21 +183,9 @@ class KyteSiteController extends ModelController
             $obj->delete();
         }
 
-        // delete Domain and SAN
-        $objs = new \Kyte\Core\Model(Domain);
-        $objs->retrieve('site', $o->id);
-        foreach ($objs->objects as $obj) {
-            $sans = new \Kyte\Core\Model(SubjectAlternativeName);
-            $sans->retrieve('domain', $obj->id);
-            foreach ($sans->objects as $san) {
-                $san->delete();
-            }
-            $params = [
-                'action' => 'acm_delete',
-                'acm_arn' => $obj->certificateArn,
-            ];
-            $sns->publish($params, $o->id);
-        }
+        // Domain/SAN rows + their ACM certificates are deleted by
+        // SiteProvisioningWorker AFTER the CloudFront distributions are torn down
+        // (an ACM cert can't be deleted while still attached to a distribution).
     }
 
     // public function hook_process_get_response(&$r) {}

--- a/src/Mvc/Model/KyteSite.php
+++ b/src/Mvc/Model/KyteSite.php
@@ -104,6 +104,23 @@ $KyteSite = [
 			'date'		=> false,
 		],
 
+		// provisioning state (SiteProvisioningWorker, KYTE-#201). Sub-state during
+		// creating/deleting is inferred from the s3*/cf* columns; these two are for
+		// surfacing failures to the dashboard and bounding retries.
+		'provisioning_message'	=> [
+			'type'		=> 't',
+			'required'	=> false,
+			'date'		=> false,
+		],
+
+		'provisioning_attempts'	=> [
+			'type'		=> 'i',
+			'required'	=> false,
+			'unsigned'	=> true,
+			'default'	=> 0,
+			'date'		=> false,
+		],
+
 		'application'	=> [
 			'type'		=> 'i',
 			'required'	=> false,


### PR DESCRIPTION
## Summary (KYTE-#201 #3, v4.13.0)

Final phase of the Lambda→cron migration. Replaces `kyte-lambda-site-management` (the SNS self-chaining state machine) + `kyte-lambda-database-transaction` (DB writer) with a cron worker that writes the DB directly. After this + soak, all 3 Lambdas + `SNS_QUEUE_SITE_MANAGEMENT` can be decommissioned.

### What changed
- **`SiteProvisioningWorker`** (`src/Cron/SiteProvisioningWorker.php`, `CronJobBase`, 30s) — advances `KyteSite` rows in `creating`/`deleting` one idempotent step per tick. Sub-state inferred from populated `s3`/`cf` columns; CloudFront create/delete polled across ticks with `heartbeat()` (never a blocking sleep). Per-site failures bump `provisioning_attempts` + record `provisioning_message`, flipping to `status=failed` after a cap.
  - CREATE: website bucket (us-east-1-aware) → media bucket → website CF → media CF (each id persisted on create) → poll until both `Deployed` → `active`.
  - DELETE: empty+delete each bucket → disable+delete each distribution → delete ACM certs + soft-delete `Domain`/`SAN` rows → `deleted`.
- **`KyteSiteController`** `new`/`delete` stop publishing to SNS — set `status` + existing content cleanup; Domain/cert teardown moved to the worker (ordering depends on the distribution being gone first).
- **`Kyte\Aws` fixes:** `S3::createBucket` omits `LocationConstraint` for us-east-1 + idempotent on `BucketAlreadyOwnedByYou`; new `S3::emptyBucket()` (paginated/version-aware); `CloudFront` applies `DefaultTTL`; `CloudFront::delete()` now passes the required `IfMatch` ETag; new `CloudFront::isEnabled()`.
- **`KyteSite`** + `provisioning_message`/`provisioning_attempts` (`migrations/4.13.0_site_provisioning.sql`); `bin/register-site-provisioning-job.php`.

### Two latent bugs caught during dev QA (and fixed here)
Both were unreachable until real AWS teardown ran — neither had ever been exercised because deletes went through the Lambda:
- `CloudFront::delete()` was missing `IfMatch` → every site delete would `InvalidIfMatchVersion` (commit 2f0b890).
- `teardownDomains` used model-name constants that don't resolve in the eval'd cron context → switched to raw SQL (commit 27098ad).

### Validation
- PHPStan level 1 clean; phpunit in CI.
- **dev19 E2E:** full create (2 buckets + 2 distributions → `active`) and full delete (incl. ACM cert + Domain/SAN teardown → `deleted`) verified against real AWS, multiple sites, `provisioning_attempts: 0` on the clean run.

### Per-install rollout (after release)
composer → `migrations/4.13.0_site_provisioning.sql` → `php bin/register-site-provisioning-job.php` → restart `kyte-cron-worker`. (Daemons already exist on all installs from v4.12.0.) Stays dormant until a site is actually created/deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)