### PR TITLE
chore(ci): run DraftServiceTest + ActivityLoggerWriteCapTest in the unit suite

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -3,12 +3,14 @@
   <testsuites>
     <testsuite name="unit">
       <file>tests/ActivityLoggerSensitivityTest.php</file>
+      <file>tests/ActivityLoggerWriteCapTest.php</file>
       <file>tests/ApiTest.php</file>
       <file>tests/AppContextStrategyTest.php</file>
       <file>tests/Bz2CodecTest.php</file>
       <file>tests/ClientIpTest.php</file>
       <file>tests/DatabaseTest.php</file>
       <file>tests/DbSessionStoreTest.php</file>
+      <file>tests/DraftServiceTest.php</file>
       <file>tests/ErrorHandlerSensitivityTest.php</file>
       <file>tests/FunctionTest.php</file>
       <file>tests/HmacSessionStrategyTest.php</file>

--- a/tests/DraftServiceTest.php
+++ b/tests/DraftServiceTest.php
@@ -51,6 +51,7 @@ class DraftServiceTest extends TestCase
         $page = new \Kyte\Core\ModelObject(KytePage);
         $page->create([
             'title'        => 'Draft Test Page',
+            's3key'        => 'draft-test-page.html',
             'state'        => 1,
             'kyte_account' => $this->accountId,
         ]);
@@ -164,7 +165,7 @@ class DraftServiceTest extends TestCase
 
         // A page id that does not belong to this account.
         $other = new \Kyte\Core\ModelObject(KytePage);
-        $other->create(['title' => 'Other', 'state' => 1, 'kyte_account' => $this->accountId + 99999]);
+        $other->create(['title' => 'Other', 's3key' => 'other-page.html', 'state' => 1, 'kyte_account' => $this->accountId + 99999]);
 
         $result = $svc->writePart($S, (int)$other->id, 'html', 'x');
         $this->assertNull($result, 'writing to a page outside the account is denied');
@@ -180,6 +181,7 @@ class DraftServiceTest extends TestCase
         $fn->create([
             'name'         => 'al_draft_test_fn',
             'controller'   => 1,
+            'type'         => 'custom',
             'code'         => bzcompress('echo 1;', 9),
             'kyte_account' => $this->accountId,
         ]);


### PR DESCRIPTION
## Summary
The `unit` testsuite in `phpunit.xml.dist` is an explicit `<file>` list, so any test file not listed never runs. **`DraftServiceTest`** (MCP draft authoring loop, v4.10.0) and **`ActivityLoggerWriteCapTest`** (the #182 ActivityLogger write-cap, v4.9.0) were never added — so despite testing shipped production features, they have **never executed in CI**. This adds them.

Both are DB-backed and follow the same pattern as existing passing tests (`ActivityLoggerSensitivityTest`, etc.), so CI here is the first real run — watching that they go green.

(First of a few small CI/test-quality "quick wins"; the flaky `ModelTest::testCreateTable` and the `symfony/http-foundation` CVE bump are follow-ups.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)