### PR TITLE
KYTE-#322: MCP site provisioning tools (create/delete/update/read) + provision scope (v4.14.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 4.14.0
+
+### Feature: MCP site-provisioning tools (create/delete/update/read) + `provision` scope — KYTE-#322
+
+New MCP tools let a token holder manage a site's lifecycle from Claude, building on the #201 `SiteProvisioningWorker` (provisioning now runs in-process, so these tools just flip state and the worker does the AWS work out of band).
+
+- **New `provision` scope** — gates infrastructure-creating tools, held separately from content `read`/`draft`/`commit` so a token can author pages/scripts without the right to spin up or tear down sites. The dispatch path has no scope enum (RequiresScope/ScopeRegistry/the token CSV all accept arbitrary strings), so the only change to make it grantable was adding `provision` to `KyteMCPTokenController::VALID_SCOPES`.
+- **`src/Mcp/Tools/SiteTools.php`** (auto-discovered): `create_site` / `delete_site` / `update_site` `[provision]`, `read_site` `[read]`. Mutations call `KyteSiteController` in internal mode (no session, mirroring `DraftService`'s publish path); `create_site`/`delete_site` flip `KyteSite.status` to `creating`/`deleting` and return immediately — callers poll `read_site` (which surfaces `status`, `provisioning_message`, and the live `cloudfront_domain`) until `active`/`deleted`. Every caller-supplied id is re-scoped to the token's account; new sites are stamped with the caller account.
+- Guarded `KyteSiteController::delete()`'s `deleted_by = $this->user->id` for the no-`KyteUser` server-side path (`isset() ? : 0`).
+- Custom-domain (`aliasDomain`) assignment is intentionally **not** exposed here — that's the ACM + DNS path (KYTE-#320). Infra ids (bucket/distribution) omitted from output; `cloudfront_domain` surfaced.
+- Tests: `tests/McpSiteToolsTest.php` (row-level create/read/update/delete + account isolation), wired into the CI unit suite. Code-only — **no migration**.
+
 ## 4.13.0
 
 ### Migration: site provisioning moved from Lambda into a cron worker — KYTE-#201

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -22,6 +22,7 @@
       <file>tests/McpPageToolsTest.php</file>
       <file>tests/McpScopeTest.php</file>
       <file>tests/McpSensitivityTest.php</file>
+      <file>tests/McpSiteToolsTest.php</file>
       <file>tests/McpTokenControllerTest.php</file>
       <file>tests/McpTokenStrategyTest.php</file>
       <file>tests/ModelTest.php</file>

--- a/src/Mcp/Tools/SiteTools.php
+++ b/src/Mcp/Tools/SiteTools.php
@@ -1,0 +1,225 @@
+<?php
+namespace Kyte\Mcp\Tools;
+
+use Kyte\Core\Api;
+use Kyte\Mcp\Attribute\RequiresScope;
+use Mcp\Capability\Attribute\McpTool;
+
+/**
+ * Site provisioning tools (create / delete / update / read a single site).
+ *
+ * Mutations are gated by the `provision` scope (held separately from content
+ * read/draft/commit, so a token can author pages/scripts without the right to
+ * spin up or tear down infrastructure). Reads use `read`.
+ *
+ * The actual AWS work (2 S3 buckets + 2 CloudFront distributions, + ACM on
+ * delete) runs OUT OF BAND in the SiteProvisioningWorker cron job (KYTE-#201) —
+ * these tools only flip the KyteSite row's status (creating/deleting) and return
+ * immediately. Callers poll read_site until status reaches "active"/"deleted"
+ * (CloudFront deploy/teardown takes minutes). Each create/delete/update goes
+ * through KyteSiteController in INTERNAL mode (no session — the controller is
+ * constructed with the internal flag, mirroring DraftService's publish path),
+ * and every caller-supplied id is re-scoped to the token's account before use.
+ *
+ * Custom-domain / aliasDomain assignment is intentionally NOT exposed here —
+ * that's the ACM + DNS path (KYTE-#320), a separate tool.
+ *
+ * Infra fields (s3BucketName, cfDistributionId, etc.) are omitted from output
+ * for the same reason PageTools omits them — deployment details, not user-facing
+ * site attributes. cfDomain (the live *.cloudfront.net URL) IS surfaced.
+ */
+final class SiteTools
+{
+    public function __construct(private readonly Api $api)
+    {
+    }
+
+    /**
+     * Create a new site in a Kyte application.
+     *
+     * Provisioning (S3 + CloudFront) runs in the background; the returned site
+     * starts at status "creating". Poll read_site until status is "active"
+     * (CloudFront deploy is typically 5-15 minutes).
+     *
+     * @param int    $application_id Application id (from list_applications).
+     * @param string $name           Human-facing site name.
+     * @param string $region         AWS region for the site's S3 buckets, e.g. "us-east-1", "us-east-2", "eu-west-1".
+     * @return array{created: bool, site?: array<string,mixed>, message?: string, error?: string}
+     */
+    #[McpTool(name: 'create_site', description: 'Create a new site in a Kyte application. Provisioning (S3 + CloudFront) runs in the background — poll read_site until status is "active".')]
+    #[RequiresScope('provision')]
+    public function createSite(int $application_id, string $name, string $region): array
+    {
+        $accountId = $this->accountIdOrZero();
+        if ($accountId === 0 || !$this->applicationBelongsToAccount($application_id, $accountId)) {
+            return ['created' => false, 'error' => 'Application not found in this account.'];
+        }
+
+        $api  = $this->api;
+        $resp = [];
+        try {
+            $controller = new \Kyte\Mvc\Controller\KyteSiteController(\KyteSite, $api, 'm/d/Y H:i:s', $resp, true);
+            // kyte_account is auto-filled from the token's account by ModelController::new.
+            $controller->new([
+                'application' => $application_id,
+                'name'        => $name,
+                'region'      => $region,
+            ]);
+        } catch (\Throwable $e) {
+            return ['created' => false, 'error' => $e->getMessage()];
+        }
+
+        $newId = isset($resp['data'][0]['id']) ? (int)$resp['data'][0]['id'] : 0;
+        if ($newId === 0) {
+            return ['created' => false, 'error' => 'Site was not created.'];
+        }
+
+        $site = new \Kyte\Core\ModelObject(\KyteSite);
+        $site->retrieve('id', $newId);
+        return [
+            'created' => true,
+            'site'    => $this->siteToArray($site),
+            'message' => 'Site created; provisioning in the background (status "creating"). Poll read_site until status is "active" (CloudFront deploy ~5-15 min).',
+        ];
+    }
+
+    /**
+     * Delete a site (and tear down its AWS resources).
+     *
+     * Flips the site to "deleting"; the worker empties+deletes the buckets,
+     * disables+deletes the distributions, and removes any ACM certs out of band.
+     * Poll read_site until status is "deleted" (teardown ~10-30 min).
+     *
+     * @param int $site_id Site id (from list_sites / read_site).
+     * @return array{deleting: bool, site_id?: int, message?: string, error?: string}
+     */
+    #[McpTool(name: 'delete_site', description: 'Delete a site and tear down its AWS resources (S3 + CloudFront + ACM) in the background. Poll read_site until status is "deleted".')]
+    #[RequiresScope('provision')]
+    public function deleteSite(int $site_id): array
+    {
+        $accountId = $this->accountIdOrZero();
+        if ($accountId === 0 || !$this->siteBelongsToAccount($site_id, $accountId)) {
+            return ['deleting' => false, 'error' => 'Site not found in this account.'];
+        }
+
+        $api  = $this->api;
+        $resp = [];
+        try {
+            $controller = new \Kyte\Mvc\Controller\KyteSiteController(\KyteSite, $api, 'm/d/Y H:i:s', $resp, true);
+            $controller->delete('id', $site_id);
+        } catch (\Throwable $e) {
+            return ['deleting' => false, 'error' => $e->getMessage()];
+        }
+
+        return [
+            'deleting' => true,
+            'site_id'  => $site_id,
+            'message'  => 'Site teardown started (status "deleting"). Poll read_site until status is "deleted" (CloudFront teardown ~10-30 min).',
+        ];
+    }
+
+    /**
+     * Update a site's settings. Only the listed fields are editable here;
+     * custom-domain (aliasDomain) assignment is a separate tool (ACM + DNS).
+     *
+     * @param int          $site_id      Site id.
+     * @param string|null  $description  New description.
+     * @param string|null  $default_lang Default language code (e.g. "en").
+     * @param string|null  $ga_code      Google Analytics measurement id.
+     * @param string|null  $gtm_code     Google Tag Manager container id.
+     * @return array{updated: bool, site?: array<string,mixed>, error?: string}
+     */
+    #[McpTool(name: 'update_site', description: 'Update a site\'s settings (description, default_lang, ga_code, gtm_code). Custom domains are handled by a separate tool.')]
+    #[RequiresScope('provision')]
+    public function updateSite(int $site_id, ?string $description = null, ?string $default_lang = null, ?string $ga_code = null, ?string $gtm_code = null): array
+    {
+        $accountId = $this->accountIdOrZero();
+        if ($accountId === 0 || !$this->siteBelongsToAccount($site_id, $accountId)) {
+            return ['updated' => false, 'error' => 'Site not found in this account.'];
+        }
+
+        $data = [];
+        if ($description !== null)  { $data['description']  = $description; }
+        if ($default_lang !== null) { $data['default_lang'] = $default_lang; }
+        if ($ga_code !== null)      { $data['ga_code']      = $ga_code; }
+        if ($gtm_code !== null)     { $data['gtm_code']     = $gtm_code; }
+        if (empty($data)) {
+            return ['updated' => false, 'error' => 'No updatable fields provided (description, default_lang, ga_code, gtm_code).'];
+        }
+
+        $api  = $this->api;
+        $resp = [];
+        try {
+            $controller = new \Kyte\Mvc\Controller\KyteSiteController(\KyteSite, $api, 'm/d/Y H:i:s', $resp, true);
+            $controller->update('id', $site_id, $data);
+        } catch (\Throwable $e) {
+            return ['updated' => false, 'error' => $e->getMessage()];
+        }
+
+        $site = new \Kyte\Core\ModelObject(\KyteSite);
+        $site->retrieve('id', $site_id);
+        return ['updated' => true, 'site' => $this->siteToArray($site)];
+    }
+
+    /**
+     * Read a single site by id, including provisioning status. Use this to poll
+     * after create_site (until "active") or delete_site (until "deleted").
+     *
+     * @param int $site_id Site id.
+     * @return array{site: array<string,mixed>|null}
+     */
+    #[McpTool(name: 'read_site', description: 'Read a single site by id, including provisioning status (creating/active/deleting/deleted/failed). Poll this after create_site/delete_site.')]
+    #[RequiresScope('read')]
+    public function readSite(int $site_id): array
+    {
+        $accountId = $this->accountIdOrZero();
+        if ($accountId === 0 || !$this->siteBelongsToAccount($site_id, $accountId)) {
+            return ['site' => null];
+        }
+        $site = new \Kyte\Core\ModelObject(\KyteSite);
+        if (!$site->retrieve('id', $site_id)) {
+            return ['site' => null];
+        }
+        return ['site' => $this->siteToArray($site)];
+    }
+
+    /**
+     * Map a KyteSite to the response shape. Surfaces the live cfDomain URL and
+     * provisioning status/message; omits raw infra ids (bucket/distribution).
+     *
+     * @return array<string,mixed>
+     */
+    private function siteToArray(\Kyte\Core\ModelObject $s): array
+    {
+        return [
+            'id'                   => (int)$s->id,
+            'name'                 => (string)($s->name ?? ''),
+            'status'               => (string)($s->status ?? ''),
+            'region'               => $s->region !== null ? (string)$s->region : null,
+            'default_lang'         => $s->default_lang !== null ? (string)$s->default_lang : null,
+            'description'          => $s->description !== null ? (string)$s->description : null,
+            'ga_code'              => $s->ga_code !== null ? (string)$s->ga_code : null,
+            'gtm_code'             => $s->gtm_code !== null ? (string)$s->gtm_code : null,
+            'alias_domain'         => $s->aliasDomain !== null ? (string)$s->aliasDomain : null,
+            'cloudfront_domain'    => $s->cfDomain !== null ? (string)$s->cfDomain : null,
+            'provisioning_message' => $s->provisioning_message !== null ? (string)$s->provisioning_message : null,
+        ];
+    }
+
+    private function accountIdOrZero(): int
+    {
+        return isset($this->api->account->id) ? (int)$this->api->account->id : 0;
+    }
+
+    private function applicationBelongsToAccount(int $applicationId, int $accountId): bool
+    {
+        $app = new \Kyte\Core\ModelObject(\Application);
+        return $app->retrieve('id', $applicationId) && (int)$app->kyte_account === $accountId;
+    }
+
+    private function siteBelongsToAccount(int $siteId, int $accountId): bool
+    {
+        $site = new \Kyte\Core\ModelObject(\KyteSite);
+        return $site->retrieve('id', $siteId) && (int)$site->kyte_account === $accountId;
+    }
+}

--- a/src/Mvc/Controller/KyteMCPTokenController.php
+++ b/src/Mvc/Controller/KyteMCPTokenController.php
@@ -40,8 +40,11 @@ namespace Kyte\Mvc\Controller;
  */
 class KyteMCPTokenController extends ModelController
 {
-    /** Allowed scope values per design doc § 5.4. */
-    private const VALID_SCOPES = ['read', 'draft', 'commit'];
+    /** Allowed scope values per design doc § 5.4. `provision` gates the
+     * infrastructure-creating MCP tools (create/delete/update site; later
+     * create_app + model migrations) — held separately from content
+     * read/draft/commit so a token can author without spin-up/tear-down rights. */
+    private const VALID_SCOPES = ['read', 'draft', 'commit', 'provision'];
 
     /** Default TTL when the request omits expires_at: 30 days. */
     private const DEFAULT_TTL_SECONDS = 30 * 86400;

--- a/src/Mvc/Controller/KyteSiteController.php
+++ b/src/Mvc/Controller/KyteSiteController.php
@@ -104,10 +104,12 @@ class KyteSiteController extends ModelController
             error_log('Site found...deleting...');
         }
         
-        // begin the deletion process
+        // begin the deletion process. deleted_by is best-effort: a server-side
+        // caller (e.g. the MCP delete_site tool, internal mode) has no KyteUser,
+        // so guard against a null $this->user rather than fatal on ->id.
         $o->save([
             'status' => 'deleting',
-            'deleted_by' => $this->user->id,    // store the user id of who initiated the delete, will add time after via lambda fx
+            'deleted_by' => isset($this->user->id) ? $this->user->id : 0,
             'date_modified' => time(),
         ]);
 

--- a/tests/McpSiteToolsTest.php
+++ b/tests/McpSiteToolsTest.php
@@ -1,0 +1,197 @@
+<?php
+namespace Kyte\Test;
+
+use Kyte\Core\Api;
+use Kyte\Mcp\Tools\SiteTools;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for SiteTools (create_site / read_site / update_site / delete_site,
+ * the MCP `provision`-scope site lifecycle tools).
+ *
+ * These exercise the tools at the row level only — the actual AWS provisioning
+ * runs in SiteProvisioningWorker, so here `create_site` lands a KyteSite in
+ * status "creating" and `delete_site` flips it to "deleting"; no S3/CloudFront.
+ *
+ * The security property under test is account isolation: every caller-supplied
+ * application_id / site_id must be re-scoped to the token's account, so a token
+ * cannot create under, read, update, or delete another account's site.
+ */
+class McpSiteToolsTest extends TestCase
+{
+    private const OWN_ACCOUNT   = 'mcp-site-test-own';
+    private const OTHER_ACCOUNT = 'mcp-site-test-other';
+
+    private Api $api;
+    private SiteTools $tools;
+    private int $ownAccountId;
+    private int $otherAccountId;
+    private int $ownAppId;
+    private int $otherAppId;
+    private int $otherSiteId;
+
+    protected function setUp(): void
+    {
+        \Kyte\Core\DBI::dbInit(KYTE_DB_USERNAME, KYTE_DB_PASSWORD, KYTE_DB_HOST, KYTE_DB_DATABASE, KYTE_DB_CHARSET, 'InnoDB');
+
+        $this->api = new Api();
+
+        // KyteSite + the child tables KyteSiteController::delete() cascades into.
+        foreach ([
+            KyteAccount, Application, KyteSite,
+            KytePage, KytePageData, Media,
+            Navigation, NavigationItem, SideNav, SideNavItem,
+            KyteSectionTemplate, KyteLibrary, KyteScript,
+        ] as $model) {
+            \Kyte\Core\DBI::createTable($model);
+        }
+
+        \Kyte\Core\DBI::query("DELETE FROM `KyteAccount` WHERE number IN ('" . self::OWN_ACCOUNT . "','" . self::OTHER_ACCOUNT . "')");
+        \Kyte\Core\DBI::query("DELETE FROM `Application` WHERE identifier LIKE 'mcp-site-test-%'");
+        \Kyte\Core\DBI::query("DELETE FROM `KyteSite` WHERE name LIKE 'McpSiteTest%'");
+
+        $this->ownAccountId   = $this->createAccount(self::OWN_ACCOUNT,   'Own');
+        $this->otherAccountId = $this->createAccount(self::OTHER_ACCOUNT, 'Other');
+
+        $this->ownAppId   = $this->createApp('mcp-site-test-own',   $this->ownAccountId);
+        $this->otherAppId = $this->createApp('mcp-site-test-other', $this->otherAccountId);
+
+        // A site owned by the OTHER account, for cross-account rejection tests.
+        $this->otherSiteId = $this->createSite('McpSiteTestOther', $this->otherAppId, $this->otherAccountId);
+
+        $this->api->account = new \Kyte\Core\ModelObject(KyteAccount);
+        $this->api->account->retrieve('id', $this->ownAccountId);
+        $this->api->mcpScopes = ['read', 'provision'];
+
+        $this->tools = new SiteTools($this->api);
+
+        $_SERVER = ['REMOTE_ADDR' => '127.0.0.1'];
+    }
+
+    public function testCreateSiteLandsInCreatingStatus(): void
+    {
+        $result = $this->tools->createSite($this->ownAppId, 'McpSiteTestNew', 'us-east-1');
+
+        $this->assertTrue($result['created'], $result['error'] ?? 'create failed');
+        $this->assertSame('McpSiteTestNew', $result['site']['name']);
+        $this->assertSame('creating', $result['site']['status'], 'a new site starts at "creating" for the worker to pick up');
+        $this->assertSame('us-east-1', $result['site']['region']);
+    }
+
+    public function testCreateSiteScopesToCallerAccount(): void
+    {
+        $result = $this->tools->createSite($this->ownAppId, 'McpSiteTestScoped', 'us-east-2');
+        $this->assertTrue($result['created']);
+
+        $site = new \Kyte\Core\ModelObject(KyteSite);
+        $site->retrieve('id', (int)$result['site']['id']);
+        $this->assertSame($this->ownAccountId, (int)$site->kyte_account, 'new site must be stamped with the caller account');
+    }
+
+    public function testCreateSiteRejectsForeignApplication(): void
+    {
+        $result = $this->tools->createSite($this->otherAppId, 'McpSiteTestEvil', 'us-east-1');
+        $this->assertFalse($result['created'], 'cannot create a site under another account\'s application');
+    }
+
+    public function testCreateSiteRejectsInvalidRegion(): void
+    {
+        $result = $this->tools->createSite($this->ownAppId, 'McpSiteTestBadRegion', 'moon-base-1');
+        $this->assertFalse($result['created'], 'an invalid AWS region is rejected by the controller');
+    }
+
+    public function testReadSiteReturnsOwnSite(): void
+    {
+        $created = $this->tools->createSite($this->ownAppId, 'McpSiteTestRead', 'us-east-1');
+        $id = (int)$created['site']['id'];
+
+        $read = $this->tools->readSite($id);
+        $this->assertNotNull($read['site']);
+        $this->assertSame('McpSiteTestRead', $read['site']['name']);
+        $this->assertSame('creating', $read['site']['status']);
+    }
+
+    public function testReadSiteRejectsForeignSite(): void
+    {
+        $this->assertNull($this->tools->readSite($this->otherSiteId)['site'], 'a foreign site_id must not be readable');
+    }
+
+    public function testUpdateSiteUpdatesSettings(): void
+    {
+        $created = $this->tools->createSite($this->ownAppId, 'McpSiteTestUpd', 'us-east-1');
+        $id = (int)$created['site']['id'];
+
+        $result = $this->tools->updateSite($id, description: 'A demo site', default_lang: 'en', ga_code: 'G-TEST', gtm_code: null);
+        $this->assertTrue($result['updated'], $result['error'] ?? 'update failed');
+        $this->assertSame('A demo site', $result['site']['description']);
+        $this->assertSame('en', $result['site']['default_lang']);
+        $this->assertSame('G-TEST', $result['site']['ga_code']);
+    }
+
+    public function testUpdateSiteRejectsForeignSite(): void
+    {
+        $result = $this->tools->updateSite($this->otherSiteId, description: 'hijack');
+        $this->assertFalse($result['updated'], 'cannot update a foreign site');
+    }
+
+    public function testUpdateSiteRejectsEmptyPayload(): void
+    {
+        $created = $this->tools->createSite($this->ownAppId, 'McpSiteTestNoop', 'us-east-1');
+        $result = $this->tools->updateSite((int)$created['site']['id']);
+        $this->assertFalse($result['updated'], 'no updatable fields provided');
+    }
+
+    public function testDeleteSiteFlipsToDeleting(): void
+    {
+        $created = $this->tools->createSite($this->ownAppId, 'McpSiteTestDel', 'us-east-1');
+        $id = (int)$created['site']['id'];
+
+        $result = $this->tools->deleteSite($id);
+        $this->assertTrue($result['deleting'], $result['error'] ?? 'delete failed');
+
+        // The worker hasn't run; the row should now be flagged for teardown.
+        $read = $this->tools->readSite($id);
+        $this->assertSame('deleting', $read['site']['status']);
+    }
+
+    public function testDeleteSiteRejectsForeignSite(): void
+    {
+        $result = $this->tools->deleteSite($this->otherSiteId);
+        $this->assertFalse($result['deleting'], 'cannot delete a foreign site');
+
+        // And the foreign site is untouched (still active, not "deleting").
+        $other = new \Kyte\Core\ModelObject(KyteSite);
+        $other->retrieve('id', $this->otherSiteId);
+        $this->assertSame('active', (string)$other->status);
+    }
+
+    private function createAccount(string $number, string $name): int
+    {
+        $obj = new \Kyte\Core\ModelObject(KyteAccount);
+        $obj->create(['number' => $number, 'name' => $name]);
+        return (int)$obj->id;
+    }
+
+    private function createApp(string $identifier, int $accountId): int
+    {
+        $obj = new \Kyte\Core\ModelObject(Application);
+        $obj->create([
+            'name'         => 'App ' . $identifier,
+            'identifier'   => $identifier,
+            'kyte_account' => $accountId,
+        ]);
+        return (int)$obj->id;
+    }
+
+    private function createSite(string $name, int $appId, int $accountId): int
+    {
+        $obj = new \Kyte\Core\ModelObject(KyteSite);
+        $obj->create([
+            'name'         => $name,
+            'status'       => 'active',
+            'application'  => $appId,
+            'kyte_account' => $accountId,
+        ]);
+        return (int)$obj->id;
+    }
+}


### PR DESCRIPTION
## Summary (KYTE-#322, v4.14.0)

New MCP tools to manage a site's lifecycle from Claude, on top of the #201 `SiteProvisioningWorker`. Code-only — **no migration**.

- **New `provision` scope** — gates infra-creating tools, separate from content read/draft/commit. The only change to make it grantable: added `provision` to `KyteMCPTokenController::VALID_SCOPES` (the dispatch path has no scope enum).
- **`src/Mcp/Tools/SiteTools.php`** (auto-discovered): `create_site`/`delete_site`/`update_site` `[provision]`, `read_site` `[read]`. Mutations call `KyteSiteController` in internal mode; create/delete flip `status` and the worker does the AWS work out of band — callers poll `read_site` (surfaces status, provisioning_message, live cloudfront_domain). Every id re-scoped to the token account.
- Guarded `KyteSiteController::delete()` `deleted_by = $this->user->id` for the no-KyteUser path.
- Custom-domain assignment deferred to #320. Infra ids omitted from output.

## Validation
- `tests/McpSiteToolsTest.php` (create/read/update/delete + account isolation) — green in CI on 8.2/8.3; PHPStan clean.
- **dev19 real-AWS harness**: create_site → worker provisioned 2 buckets + 2 CloudFront distributions (0 errors).
- **Live MCP dogfood** (after session restart): all four tools called over the real MCP transport with a `provision`-scoped token — create → update → read → delete, full stack confirmed.

## Rollout (code-only)
composer update + reload php-fpm/httpd per install (no migration; daemons already run the #201 worker everywhere). Tools stay dormant until a token is granted `provision` (Shipyard token-UI scope checkboxes are a separate follow-up; interim is a SQL scope update).

🤖 Generated with [Claude Code](https://claude.com/claude-code)