### PR TITLE
KYTE-#325 PR A: model-layer fixes & hardening

### DIFF
--- a/migrations/4.15.0_modelattribute_decimal.sql
+++ b/migrations/4.15.0_modelattribute_decimal.sql
@@ -1,0 +1,21 @@
+-- =========================================================================
+-- Kyte v4.15.0 - ModelAttribute decimal precision/scale (KYTE-#325 PR A)
+-- =========================================================================
+-- IMPORTANT: Backup your database before running this migration.
+--
+-- Adds `precision` and `scale` to ModelAttribute so the decimal (`d`) column
+-- type works end-to-end. DBI::buildFieldDefinition emits `decimal(p,s)` only
+-- when both are present; previously these were never stored or passed through,
+-- so a `d` attribute produced an invalid column definition. Both are nullable
+-- and only consumed for type='d', so this is a no-op for every existing row.
+--
+-- ADDITIVE / migration-first / inert on older code. PascalCase table.
+--
+-- See src/Mvc/Model/ModelAttribute.php,
+-- src/Mvc/Controller/DataModelController.php::prepareModelDef,
+-- src/Core/DBI.php::buildFieldDefinition.
+-- =========================================================================
+
+ALTER TABLE `ModelAttribute`
+    ADD COLUMN `precision` INT UNSIGNED DEFAULT NULL AFTER `size`,
+    ADD COLUMN `scale`     INT UNSIGNED DEFAULT NULL AFTER `precision`;

--- a/src/Core/DBI.php
+++ b/src/Core/DBI.php
@@ -716,7 +716,7 @@ class DBI {
 		// db connection
 		$con = self::getConnection();
 
-		$tbl_sql = "DROP TABLE `$tbl_name`";
+		$tbl_sql = "DROP TABLE IF EXISTS `$tbl_name`";
 
 		$result = $con->query($tbl_sql);
 		if($result === false) {
@@ -741,7 +741,7 @@ class DBI {
 		// db connection
 		$con = self::getConnection();
 
-		$tbl_sql = "ALTER TABLE `$tbl_name_old` RENAME TO `$tbl_name_news`";
+		$tbl_sql = "ALTER TABLE `$tbl_name_old` RENAME TO `$tbl_name_new`";
 
 		$result = $con->query($tbl_sql);
 		if($result === false) {

--- a/src/Core/DBI.php
+++ b/src/Core/DBI.php
@@ -544,6 +544,8 @@ class DBI {
 				case 'd':
 					if (array_key_exists('precision', $attrs) && array_key_exists('scale', $attrs)) {
 						$field .= ' decimal(' . $attrs['precision'] . ',' . $attrs['scale'] . ')';
+					} else {
+						throw new \Exception("decimal requires precision and scale to be declared for column $name of table $tableName.");
 					}
 					break;
 				case 't':

--- a/src/Mvc/Controller/DataModelController.php
+++ b/src/Mvc/Controller/DataModelController.php
@@ -22,6 +22,16 @@ class DataModelController extends ModelController
             $attrs['size'] = $o->size;
         }
 
+        // decimal precision/scale — only meaningful for the `d` type, where
+        // DBI::buildFieldDefinition needs both to emit decimal(precision,scale).
+        if ($o->type == 'd') {
+            if (!isset($o->precision) || !isset($o->scale) || $o->precision === '' || $o->scale === '') {
+                throw new \Exception("Decimal attribute requires both precision and scale.");
+            }
+            $attrs['precision'] = $o->precision;
+            $attrs['scale'] = $o->scale;
+        }
+
         // unsigned
         if ($o->unsigned == 1) {
             $attrs['unsigned'] = true;
@@ -124,6 +134,13 @@ class DataModelController extends ModelController
                     throw new \Exception("Unknown model definition");
                 }
 
+                // Refuse to alter a kyte-locked model (system/critical model).
+                // Guard before any DB switch or DDL so a locked row never
+                // reaches the app database.
+                if ((int)$o->kyte_locked === 1) {
+                    throw new \Exception("Model '{$o->name}' is locked and cannot be modified.");
+                }
+
                 // Only run the table-rename path when the request actually
                 // carries a (different) name. A metadata-only partial PUT —
                 // e.g. the Settings tab toggling `sensitive` — omits `name`,
@@ -171,6 +188,31 @@ class DataModelController extends ModelController
     public function hook_response_data($method, $o, &$r = null, &$d = null) {
         switch ($method) {
             case 'delete':
+                // Refuse to drop a kyte-locked model (system/critical model).
+                // Guard before any cascade delete, DB switch, or DROP TABLE.
+                if ((int)$o->kyte_locked === 1) {
+                    throw new \Exception("Model '{$o->name}' is locked and cannot be deleted.");
+                }
+
+                // FK-dependency guard: refuse to drop a model that another
+                // model's attribute still references via foreignKeyModel.
+                // Account-scoped; the model's own attributes are excluded since
+                // they are deleted along with it.
+                $dependents = new \Kyte\Core\Model(ModelAttribute);
+                $dependents->retrieve('foreignKeyModel', $o->id, false, [['field' => 'kyte_account', 'value' => $this->api->account->id]]);
+                $blockingNames = [];
+                foreach ($dependents->objects as $dep) {
+                    if ($dep->dataModel == $o->id) {
+                        continue;
+                    }
+                    $depModel = new \Kyte\Core\ModelObject(DataModel);
+                    $depModelName = $depModel->retrieve('id', $dep->dataModel) ? $depModel->name : "model #{$dep->dataModel}";
+                    $blockingNames[] = "{$depModelName}.{$dep->name}";
+                }
+                if (!empty($blockingNames)) {
+                    throw new \Exception("Cannot delete model '{$o->name}': it is referenced by foreign key(s) " . implode(', ', $blockingNames) . ". Remove the referencing attribute(s) first.");
+                }
+
                 // delete model attributes
                 $attrs = new \Kyte\Core\Model(ModelAttribute);
                 $attrs->retrieve("dataModel", $o->id);
@@ -187,7 +229,8 @@ class DataModelController extends ModelController
                 //     $ctrl->delete('id', $controller->id);
                 // }
 
-                // TODO: consider situation where there are external tables and foreign keys
+                // Cross-model foreign-key references are guarded above; any
+                // remaining external-table cleanup is the caller's responsibility.
 
                 // switch dbs
                 $app = new \Kyte\Core\ModelObject(Application);

--- a/src/Mvc/Controller/DataModelController.php
+++ b/src/Mvc/Controller/DataModelController.php
@@ -204,8 +204,20 @@ class DataModelController extends ModelController
                 
                 // return to kyte db
                 \Kyte\Core\Api::dbswitch();
+
+                // Invalidate the cached model struct for this app — the model is
+                // gone, so the next request must not load it from the stale cache.
+                \Kyte\Core\Api::clearModelCache($o->application);
                 break;
-            
+
+            case 'new':
+            case 'update':
+                // A create or rename changed this app's model set / a struct name;
+                // flush the cached struct so the next request loads fresh rather
+                // than serving the stale cache for up to its TTL.
+                \Kyte\Core\Api::clearModelCache($o->application);
+                break;
+
             default:
                 break;
         }

--- a/src/Mvc/Controller/ModelAttributeController.php
+++ b/src/Mvc/Controller/ModelAttributeController.php
@@ -125,6 +125,10 @@ class ModelAttributeController extends ModelController
                 $tbl->save([
                     'model_definition' => json_encode($model_definition)
                 ]);
+                // Invalidate the cached model struct so the schema change (add /
+                // change / drop column) is served immediately — the file cache
+                // would otherwise serve the stale struct for up to its TTL (1h).
+                \Kyte\Core\Api::clearModelCache($tbl->application);
                 break;
             
             default:

--- a/src/Mvc/Controller/ModelAttributeController.php
+++ b/src/Mvc/Controller/ModelAttributeController.php
@@ -60,6 +60,12 @@ class ModelAttributeController extends ModelController
                 // `sensitive` was persisted. The field-edit form always sends
                 // `name` for real schema changes, so this preserves that path.
                 if (isset($r['name'])) {
+                    // Refuse to alter a kyte-locked attribute (system/critical
+                    // column). Guard before any DB switch or DDL.
+                    if ((int)$o->kyte_locked === 1) {
+                        throw new \Exception("Attribute '{$o->name}' is locked and cannot be modified.");
+                    }
+
                     $tbl = new \Kyte\Core\ModelObject(DataModel);
                     if (!$tbl->retrieve('id', $o->dataModel)) {
                         throw new \Exception("Unable to find associated data model.");
@@ -98,7 +104,27 @@ class ModelAttributeController extends ModelController
 
         switch ($method) {
             case 'delete':
-                // TODO: consider situation where there are external tables and foreign keys
+                // Refuse to drop a kyte-locked attribute (system/critical
+                // column). Guard before any DB switch or DROP COLUMN.
+                if ((int)$o->kyte_locked === 1) {
+                    throw new \Exception("Attribute '{$o->name}' is locked and cannot be deleted.");
+                }
+
+                // FK-dependency guard: refuse to drop a column that another
+                // attribute still references via foreignKeyAttribute.
+                // Account-scoped.
+                $dependents = new \Kyte\Core\Model(ModelAttribute);
+                $dependents->retrieve('foreignKeyAttribute', $o->id, false, [['field' => 'kyte_account', 'value' => $this->api->account->id]]);
+                $blockingNames = [];
+                foreach ($dependents->objects as $dep) {
+                    $depModel = new \Kyte\Core\ModelObject(DataModel);
+                    $depModelName = $depModel->retrieve('id', $dep->dataModel) ? $depModel->name : "model #{$dep->dataModel}";
+                    $blockingNames[] = "{$depModelName}.{$dep->name}";
+                }
+                if (!empty($blockingNames)) {
+                    throw new \Exception("Cannot delete attribute '{$o->name}': it is referenced by foreign key(s) " . implode(', ', $blockingNames) . ". Remove the referencing attribute(s) first.");
+                }
+
                 $d = false; // set auto delete external tables to false since there are none.
                 // switch dbs
                 $app = new \Kyte\Core\ModelObject(Application);

--- a/src/Mvc/Model/ModelAttribute.php
+++ b/src/Mvc/Model/ModelAttribute.php
@@ -29,6 +29,26 @@ $ModelAttribute = [
 			'date'		=> false,
 		],
 
+		// total number of digits for a decimal (`d`) column, e.g. 10 in
+		// decimal(10,2). Required (alongside `scale`) for the decimal type.
+		'precision'	=> [
+			'type'		=> 'i',
+			'required'	=> false,
+			'size'		=> 11,
+			'unsigned'	=> true,
+			'date'		=> false,
+		],
+
+		// number of digits after the decimal point, e.g. 2 in decimal(10,2).
+		// Required (alongside `precision`) for the decimal type.
+		'scale'		=> [
+			'type'		=> 'i',
+			'required'	=> false,
+			'size'		=> 11,
+			'unsigned'	=> true,
+			'date'		=> false,
+		],
+
 		'unsigned'	=> [
 			'type'		=> 'i',
 			'required'	=> false,


### PR DESCRIPTION
## KYTE-#325 — PR A (model-layer fixes / hardening)

First of two PRs for the MCP schema-management work. PR A hardens the existing model/DDL path (no MCP surface yet — that's PR B). Benefits Shipyard too, since it drives the same controllers.

Builds on `2ae652c` (renameTable typo, dropTable IF EXISTS, model-cache flush).

### Changes
1. **Enforce `kyte_locked` on the DDL path.** `DataModelController` and `ModelAttributeController` now refuse update/delete of a locked model or attribute, guarding *before* any DB switch or DDL so a locked row never reaches the app database.
2. **FK-dependency guard before drop.** Dropping a model is refused while another model's attribute references it via `foreignKeyModel`; dropping a column is refused while another attribute references it via `foreignKeyAttribute`. Both account-scoped, with an error naming the blocking `model.attribute(s)`. Replaces the two stale "external tables and foreign keys" TODOs.
3. **Decimal (`d`) support.** Adds `precision`/`scale` columns to `ModelAttribute` (+ migration `4.15.0_modelattribute_decimal.sql`), passes them through `DataModelController::prepareModelDef` for type `d`, and hardens `DBI::buildFieldDefinition` to throw on a `d` column missing precision/scale instead of emitting invalid SQL.

### Migration
`migrations/4.15.0_modelattribute_decimal.sql` — additive, nullable, no-op for existing rows.

### Verification
- PHPStan level 1 (`php:8.2-cli`, `-d memory_limit=512M`) — **green**.
- Unit suite (240 tests) — **green** against MariaDB 10.5 via `tests/docker-compose.test.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)