### PR TITLE
KYTE-#325 PR B: MCP schema-management tools + schema scope

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -147,7 +147,7 @@ parameters:
 		-
 			message: '#^Constant VERBOSE_LOG not found\.$#'
 			identifier: constant.notFound
-			count: 3
+			count: 4
 			path: src/Core/Api.php
 
 		-

--- a/src/Core/Api.php
+++ b/src/Core/Api.php
@@ -472,9 +472,21 @@ class Api
 
 		foreach($models->objects as $object) {
 			$model_definition = json_decode($object->model_definition, true);
+			// Skip rows whose stored definition is missing or corrupt — a single
+			// bad row must not break loading (and define()ing) the rest of the
+			// app's models. Without this, json_decode returns null and the
+			// name lookup/define() below would choke on a null model name.
+			if (!is_array($model_definition) || empty($model_definition['name'])) {
+				if (VERBOSE_LOG) {
+					error_log("Skipping app model with missing/invalid model_definition (DataModel id {$object->id}).");
+				}
+				continue;
+			}
 			$model_definition['appId'] = $app->identifier;
 			$modelDefs[$model_definition['name']] = $model_definition;
-			define($model_definition['name'], $model_definition);
+			if (!defined($model_definition['name'])) {
+				define($model_definition['name'], $model_definition);
+			}
 		}
 
 		// Update caches

--- a/src/Mcp/Tools/ModelTools.php
+++ b/src/Mcp/Tools/ModelTools.php
@@ -146,6 +146,347 @@ final class ModelTools
         ];
     }
 
+    /**
+     * Create a new data model (table) in a Kyte application.
+     *
+     * Applies a real CREATE TABLE migration against the application's database
+     * (with the standard Kyte primary key + audit columns). Add fields with
+     * add_attribute. The model name must be unique within the application and
+     * must not collide with a framework model name.
+     *
+     * @param int    $application_id Application id (from list_applications).
+     * @param string $name           Model name (also the table name).
+     * @return array{created: bool, model?: array<string,mixed>, error?: string}
+     */
+    #[McpTool(name: 'create_model', description: 'Create a new data model in a Kyte application. Applies a real CREATE TABLE migration; add fields with add_attribute.')]
+    #[RequiresScope('schema')]
+    public function createModel(int $application_id, string $name): array
+    {
+        $accountId = $this->accountIdOrZero();
+        if ($accountId === 0 || !$this->applicationBelongsToAccount($application_id, $accountId)) {
+            return ['created' => false, 'error' => 'Application not found in this account.'];
+        }
+        if (trim($name) === '') {
+            return ['created' => false, 'error' => 'Model name is required.'];
+        }
+
+        $resp = [];
+        try {
+            $controller = $this->dataModelController($resp);
+            // kyte_account is auto-filled from the token's account by ModelController::new.
+            $controller->new(['application' => $application_id, 'name' => $name]);
+        } catch (\Throwable $e) {
+            return ['created' => false, 'error' => $e->getMessage()];
+        }
+
+        $newId = isset($resp['data'][0]['id']) ? (int)$resp['data'][0]['id'] : 0;
+        if ($newId === 0) {
+            return ['created' => false, 'error' => 'Model was not created.'];
+        }
+
+        return ['created' => true, 'model' => $this->modelSummary($newId)];
+    }
+
+    /**
+     * Add an attribute (column) to a data model.
+     *
+     * Applies a real ADD COLUMN migration. For the decimal type ("d") both
+     * precision and scale are required. For a foreign-key column pass
+     * foreign_key_model (the referenced model's id); the reference always
+     * targets that model's primary key.
+     *
+     * @param int         $model_id          DataModel id (from list_models).
+     * @param string      $name              Column name.
+     * @param string      $type              Column type code: i (int), bi (bigint), s (varchar — size required), d (decimal — precision+scale required), t/tt/mt/lt (text variants), b/tb/mb/lb (blob variants), date.
+     * @param int|null    $size              Size/length (required for s; optional for i/bi).
+     * @param int|null    $precision         Total digits — required for type d.
+     * @param int|null    $scale             Fractional digits — required for type d.
+     * @param bool        $unsigned          Whether a numeric column is unsigned.
+     * @param bool        $required          Whether the column is NOT NULL.
+     * @param string|null $default           Default value.
+     * @param int|null    $foreign_key_model Referenced model id for a foreign-key column.
+     * @return array{added: bool, attribute?: array<string,mixed>, error?: string}
+     */
+    #[McpTool(name: 'add_attribute', description: 'Add an attribute (column) to a data model. Applies a real ADD COLUMN migration. Decimal (d) needs precision+scale; varchar (s) needs size.')]
+    #[RequiresScope('schema')]
+    public function addAttribute(int $model_id, string $name, string $type, ?int $size = null, ?int $precision = null, ?int $scale = null, bool $unsigned = false, bool $required = false, ?string $default = null, ?int $foreign_key_model = null): array
+    {
+        $accountId = $this->accountIdOrZero();
+        if ($accountId === 0 || !$this->modelBelongsToAccount($model_id, $accountId)) {
+            return ['added' => false, 'error' => 'Model not found in this account.'];
+        }
+        if (trim($name) === '') {
+            return ['added' => false, 'error' => 'Attribute name is required.'];
+        }
+        if ($foreign_key_model !== null && !$this->modelBelongsToAccount($foreign_key_model, $accountId)) {
+            return ['added' => false, 'error' => 'Foreign-key model not found in this account.'];
+        }
+
+        $data = $this->attributeData($model_id, $name, $type, $size, $precision, $scale, $unsigned, $required, $default, $foreign_key_model);
+
+        $resp = [];
+        try {
+            $controller = $this->modelAttributeController($resp);
+            $controller->new($data);
+        } catch (\Throwable $e) {
+            return ['added' => false, 'error' => $e->getMessage()];
+        }
+
+        $newId = isset($resp['data'][0]['id']) ? (int)$resp['data'][0]['id'] : 0;
+        if ($newId === 0) {
+            return ['added' => false, 'error' => 'Attribute was not added.'];
+        }
+
+        return ['added' => true, 'attribute' => $this->attributeSummary($newId)];
+    }
+
+    /**
+     * Update an attribute's definition (applies a real CHANGE COLUMN migration).
+     *
+     * Only the provided fields change; `name` must be supplied because the
+     * underlying ALTER ... CHANGE rewrites the full column definition. To
+     * convert to/keep a decimal column, supply precision and scale.
+     *
+     * @param int         $attribute_id      ModelAttribute id.
+     * @param string      $name              Column name (new or unchanged — required).
+     * @param string      $type              Column type code (see add_attribute).
+     * @param int|null    $size              Size/length.
+     * @param int|null    $precision         Total digits — required for type d.
+     * @param int|null    $scale             Fractional digits — required for type d.
+     * @param bool        $unsigned          Whether a numeric column is unsigned.
+     * @param bool        $required          Whether the column is NOT NULL.
+     * @param string|null $default           Default value.
+     * @param int|null    $foreign_key_model Referenced model id for a foreign-key column.
+     * @return array{updated: bool, attribute?: array<string,mixed>, error?: string}
+     */
+    #[McpTool(name: 'update_attribute', description: 'Update an attribute definition (applies a real CHANGE COLUMN migration). name is required since the column definition is rewritten in full.')]
+    #[RequiresScope('schema')]
+    public function updateAttribute(int $attribute_id, string $name, string $type, ?int $size = null, ?int $precision = null, ?int $scale = null, bool $unsigned = false, bool $required = false, ?string $default = null, ?int $foreign_key_model = null): array
+    {
+        $accountId = $this->accountIdOrZero();
+        $attr = $this->ownedAttribute($attribute_id, $accountId);
+        if ($attr === null) {
+            return ['updated' => false, 'error' => 'Attribute not found in this account.'];
+        }
+        if (trim($name) === '') {
+            return ['updated' => false, 'error' => 'Attribute name is required.'];
+        }
+        if ($foreign_key_model !== null && !$this->modelBelongsToAccount($foreign_key_model, $accountId)) {
+            return ['updated' => false, 'error' => 'Foreign-key model not found in this account.'];
+        }
+
+        $data = $this->attributeData((int)$attr->dataModel, $name, $type, $size, $precision, $scale, $unsigned, $required, $default, $foreign_key_model);
+        unset($data['dataModel']); // not editable on update
+
+        $resp = [];
+        try {
+            $controller = $this->modelAttributeController($resp);
+            $controller->update('id', $attribute_id, $data);
+        } catch (\Throwable $e) {
+            return ['updated' => false, 'error' => $e->getMessage()];
+        }
+
+        return ['updated' => true, 'attribute' => $this->attributeSummary($attribute_id)];
+    }
+
+    /**
+     * Rename a data model (applies a real RENAME TABLE migration).
+     *
+     * @param int    $model_id DataModel id.
+     * @param string $new_name New model/table name (unique within the app).
+     * @return array{renamed: bool, model?: array<string,mixed>, error?: string}
+     */
+    #[McpTool(name: 'rename_model', description: 'Rename a data model (applies a real RENAME TABLE migration).')]
+    #[RequiresScope('schema')]
+    public function renameModel(int $model_id, string $new_name): array
+    {
+        $accountId = $this->accountIdOrZero();
+        $dm = $this->ownedModel($model_id, $accountId);
+        if ($dm === null) {
+            return ['renamed' => false, 'error' => 'Model not found in this account.'];
+        }
+        if (trim($new_name) === '') {
+            return ['renamed' => false, 'error' => 'New model name is required.'];
+        }
+
+        // DataModelController::update guards on `defined($o->name)` — it requires
+        // the model to be registered as a runtime constant. The HTTP pipeline
+        // does this via Api::loadAppModels during routing, but the MCP path
+        // bypasses routing, so register the app's models here first (mirrors
+        // AppModelWrapperController). clearModelCache after a prior create keeps
+        // this read fresh from the DB.
+        $app = new \Kyte\Core\ModelObject(\Application);
+        if ($app->retrieve('id', (int)$dm->application)) {
+            \Kyte\Core\Api::loadAppModels($app);
+        }
+
+        $resp = [];
+        try {
+            $controller = $this->dataModelController($resp);
+            $controller->update('id', $model_id, [
+                'name'        => $new_name,
+                'application' => (int)$dm->application,
+            ]);
+        } catch (\Throwable $e) {
+            return ['renamed' => false, 'error' => $e->getMessage()];
+        }
+
+        return ['renamed' => true, 'model' => $this->modelSummary($model_id)];
+    }
+
+    /**
+     * Remove an attribute (column) from a data model.
+     *
+     * DESTRUCTIVE — applies a real DROP COLUMN migration and the column's data
+     * is lost. Requires confirm_destructive=true; refused while another
+     * attribute references this column via a foreign key.
+     *
+     * @param int  $attribute_id       ModelAttribute id.
+     * @param bool $confirm_destructive Must be true to proceed (drops the column and its data).
+     * @return array{removed: bool, attribute_id?: int, error?: string}
+     */
+    #[McpTool(name: 'remove_attribute', description: 'Remove an attribute (column) from a data model. DESTRUCTIVE — applies a real DROP COLUMN migration; requires confirm_destructive=true.')]
+    #[RequiresScope('schema')]
+    public function removeAttribute(int $attribute_id, bool $confirm_destructive = false): array
+    {
+        if ($confirm_destructive !== true) {
+            return ['removed' => false, 'error' => 'Refused: dropping a column is destructive and loses its data. Re-call with confirm_destructive=true to proceed.'];
+        }
+
+        $accountId = $this->accountIdOrZero();
+        $attr = $this->ownedAttribute($attribute_id, $accountId);
+        if ($attr === null) {
+            return ['removed' => false, 'error' => 'Attribute not found in this account.'];
+        }
+
+        $resp = [];
+        try {
+            $controller = $this->modelAttributeController($resp);
+            $controller->delete('id', $attribute_id);
+        } catch (\Throwable $e) {
+            return ['removed' => false, 'error' => $e->getMessage()];
+        }
+
+        // The controller fails closed but does not throw on a no-op delete;
+        // confirm the row is gone before reporting success.
+        $check = new \Kyte\Core\ModelObject(\ModelAttribute);
+        if ($check->retrieve('id', $attribute_id) && (int)$check->kyte_account === $accountId) {
+            return ['removed' => false, 'error' => 'Attribute was not removed.'];
+        }
+
+        return ['removed' => true, 'attribute_id' => $attribute_id];
+    }
+
+    /**
+     * Delete a data model.
+     *
+     * DESTRUCTIVE — applies a real DROP TABLE migration and all rows are lost.
+     * Requires confirm_destructive=true; refused while another model references
+     * this one via a foreign key.
+     *
+     * @param int  $model_id           DataModel id.
+     * @param bool $confirm_destructive Must be true to proceed (drops the table and its data).
+     * @return array{deleted: bool, model_id?: int, error?: string}
+     */
+    #[McpTool(name: 'delete_model', description: 'Delete a data model. DESTRUCTIVE — applies a real DROP TABLE migration; requires confirm_destructive=true.')]
+    #[RequiresScope('schema')]
+    public function deleteModel(int $model_id, bool $confirm_destructive = false): array
+    {
+        if ($confirm_destructive !== true) {
+            return ['deleted' => false, 'error' => 'Refused: dropping a model is destructive and loses all its data. Re-call with confirm_destructive=true to proceed.'];
+        }
+
+        $accountId = $this->accountIdOrZero();
+        if ($accountId === 0 || $this->ownedModel($model_id, $accountId) === null) {
+            return ['deleted' => false, 'error' => 'Model not found in this account.'];
+        }
+
+        $resp = [];
+        try {
+            $controller = $this->dataModelController($resp);
+            $controller->delete('id', $model_id);
+        } catch (\Throwable $e) {
+            return ['deleted' => false, 'error' => $e->getMessage()];
+        }
+
+        $check = new \Kyte\Core\ModelObject(\DataModel);
+        if ($check->retrieve('id', $model_id) && (int)$check->kyte_account === $accountId) {
+            return ['deleted' => false, 'error' => 'Model was not deleted.'];
+        }
+
+        return ['deleted' => true, 'model_id' => $model_id];
+    }
+
+    private function dataModelController(array &$resp): \Kyte\Mvc\Controller\DataModelController
+    {
+        return new \Kyte\Mvc\Controller\DataModelController(\DataModel, $this->api, 'm/d/Y H:i:s', $resp, true);
+    }
+
+    private function modelAttributeController(array &$resp): \Kyte\Mvc\Controller\ModelAttributeController
+    {
+        return new \Kyte\Mvc\Controller\ModelAttributeController(\ModelAttribute, $this->api, 'm/d/Y H:i:s', $resp, true);
+    }
+
+    /**
+     * Build the controller payload for an attribute create/update. Optional
+     * fields are only included when set so the controller / prepareModelDef
+     * applies its own defaults for the rest.
+     *
+     * @return array<string,mixed>
+     */
+    private function attributeData(int $modelId, string $name, string $type, ?int $size, ?int $precision, ?int $scale, bool $unsigned, bool $required, ?string $default, ?int $foreignKeyModel): array
+    {
+        $data = [
+            'dataModel' => $modelId,
+            'name'      => $name,
+            'type'      => $type,
+            'required'  => $required ? 1 : 0,
+            'unsigned'  => $unsigned ? 1 : 0,
+        ];
+        if ($size !== null)            { $data['size']      = $size; }
+        if ($precision !== null)       { $data['precision'] = $precision; }
+        if ($scale !== null)           { $data['scale']     = $scale; }
+        if ($default !== null)         { $data['defaults']  = $default; }
+        if ($foreignKeyModel !== null) { $data['foreignKeyModel'] = $foreignKeyModel; }
+        return $data;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function modelSummary(int $modelId): array
+    {
+        $dm = new \Kyte\Core\ModelObject(\DataModel);
+        $dm->retrieve('id', $modelId);
+        return [
+            'id'          => (int)$dm->id,
+            'name'        => (string)($dm->name ?? ''),
+            'application' => $dm->application !== null ? (int)$dm->application : null,
+            'kyte_locked' => (int)($dm->kyte_locked ?? 0) === 1,
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function attributeSummary(int $attributeId): array
+    {
+        $a = new \Kyte\Core\ModelObject(\ModelAttribute);
+        $a->retrieve('id', $attributeId);
+        return [
+            'id'        => (int)$a->id,
+            'name'      => (string)($a->name ?? ''),
+            'type'      => (string)($a->type ?? ''),
+            'data_model' => $a->dataModel !== null ? (int)$a->dataModel : null,
+            'size'      => $a->size !== null ? (int)$a->size : null,
+            'precision' => $a->precision !== null ? (int)$a->precision : null,
+            'scale'     => $a->scale !== null ? (int)$a->scale : null,
+            'required'  => (int)($a->required ?? 0) === 1,
+            'unsigned'  => (int)($a->unsigned ?? 0) === 1,
+            'foreign_key_model' => $a->foreignKeyModel !== null ? (int)$a->foreignKeyModel : null,
+        ];
+    }
+
     private function accountIdOrZero(): int
     {
         return isset($this->api->account->id) ? (int)$this->api->account->id : 0;
@@ -155,5 +496,40 @@ final class ModelTools
     {
         $app = new \Kyte\Core\ModelObject(\Application);
         return $app->retrieve('id', $applicationId) && (int)$app->kyte_account === $accountId;
+    }
+
+    private function modelBelongsToAccount(int $modelId, int $accountId): bool
+    {
+        return $this->ownedModel($modelId, $accountId) !== null;
+    }
+
+    /**
+     * Retrieve a DataModel only if it belongs to the given account.
+     */
+    private function ownedModel(int $modelId, int $accountId): ?\Kyte\Core\ModelObject
+    {
+        if ($accountId === 0) {
+            return null;
+        }
+        $dm = new \Kyte\Core\ModelObject(\DataModel);
+        if (!$dm->retrieve('id', $modelId) || (int)$dm->kyte_account !== $accountId) {
+            return null;
+        }
+        return $dm;
+    }
+
+    /**
+     * Retrieve a ModelAttribute only if it belongs to the given account.
+     */
+    private function ownedAttribute(int $attributeId, int $accountId): ?\Kyte\Core\ModelObject
+    {
+        if ($accountId === 0) {
+            return null;
+        }
+        $attr = new \Kyte\Core\ModelObject(\ModelAttribute);
+        if (!$attr->retrieve('id', $attributeId) || (int)$attr->kyte_account !== $accountId) {
+            return null;
+        }
+        return $attr;
     }
 }

--- a/src/Mvc/Controller/DataModelController.php
+++ b/src/Mvc/Controller/DataModelController.php
@@ -11,10 +11,15 @@ class DataModelController extends ModelController
     // public function hook_prequery($method, &$field, &$value, &$conditions, &$all, &$order) {}
 
     public static function prepareModelDef($o) {
+        // Optional flags/values may be absent when the caller sends a partial
+        // attribute payload (e.g. the MCP schema tools, which only set the
+        // fields they care about). Read them defensively so a missing property
+        // doesn't emit an undefined-property warning or a null-to-strlen
+        // deprecation; the dashboard form still sends the full set.
         $attrs = [
             'type'      => $o->type == 'date' ? 'i' : $o->type,
             'date'      => $o->type == 'date',
-            'required'  => $o->required == 1,
+            'required'  => isset($o->required) && $o->required == 1,
         ];
 
         // size
@@ -33,22 +38,22 @@ class DataModelController extends ModelController
         }
 
         // unsigned
-        if ($o->unsigned == 1) {
+        if (!empty($o->unsigned)) {
             $attrs['unsigned'] = true;
         }
 
         // protected
-        if ($o->protected == 1) {
+        if (!empty($o->protected)) {
             $attrs['protected'] = true;
         }
 
         // password
-        if ($o->password == 1) {
+        if (!empty($o->password)) {
             $attrs['password'] = true;
         }
 
         // defaults
-        if (strlen($o->defaults) > 0) {
+        if (isset($o->defaults) && strlen((string)$o->defaults) > 0) {
             $attrs['default'] = $o->defaults;
         }
 

--- a/src/Mvc/Controller/KyteMCPTokenController.php
+++ b/src/Mvc/Controller/KyteMCPTokenController.php
@@ -41,10 +41,14 @@ namespace Kyte\Mvc\Controller;
 class KyteMCPTokenController extends ModelController
 {
     /** Allowed scope values per design doc § 5.4. `provision` gates the
-     * infrastructure-creating MCP tools (create/delete/update site; later
-     * create_app + model migrations) — held separately from content
-     * read/draft/commit so a token can author without spin-up/tear-down rights. */
-    private const VALID_SCOPES = ['read', 'draft', 'commit', 'provision'];
+     * infrastructure-creating MCP tools (create/delete/update site) — held
+     * separately from content read/draft/commit so a token can author without
+     * spin-up/tear-down rights. `schema` gates the model-migration tools
+     * (create/alter/drop model + attribute, where a change applies a real
+     * DDL migration) — held separately from `provision` so a token can be
+     * granted schema-editing rights without site spin-up/tear-down, and vice
+     * versa. Scopes are not hierarchical. */
+    private const VALID_SCOPES = ['read', 'draft', 'commit', 'provision', 'schema'];
 
     /** Default TTL when the request omits expires_at: 30 days. */
     private const DEFAULT_TTL_SECONDS = 30 * 86400;

--- a/tests/McpModelToolsTest.php
+++ b/tests/McpModelToolsTest.php
@@ -6,17 +6,42 @@ use Kyte\Mcp\Tools\ModelTools;
 use PHPUnit\Framework\TestCase;
 
 /**
- * Unit tests for ModelTools (list_models / read_model).
+ * Unit tests for ModelTools.
  *
- * Same shape as McpControllerToolsTest — drives the tool methods
- * directly, covers the cross-account isolation contract, plus the
- * read_model JSON-decode behavior (well-formed JSON, missing JSON,
- * malformed JSON).
+ * Two layers:
+ *   1. Read tools (list_models / read_model) — metadata + JSON-decode + the
+ *      cross-account isolation contract. These drive rows created directly.
+ *   2. Write tools (create_model / add_attribute / update_attribute /
+ *      rename_model / remove_attribute / delete_model) — the `schema`-scope
+ *      migration tools. Unlike SiteTools (whose AWS work is deferred to a
+ *      worker), the model controllers run REAL DDL synchronously against the
+ *      application's own database. Api::dbappconnect refuses an empty password,
+ *      so these tests point the application at the test database via a
+ *      dedicated password-bearing MySQL user; CREATE/ALTER/DROP TABLE then run
+ *      against the test schema and are cleaned up here.
+ *
+ * The security property under test for the write tools is account isolation:
+ * every caller-supplied model/attribute id is re-scoped to the token's account,
+ * and the destructive ops (remove_attribute / delete_model) refuse without
+ * confirm_destructive.
  */
 class McpModelToolsTest extends TestCase
 {
     private const OWN_ACCOUNT   = 'mcp-model-test-own';
     private const OTHER_ACCOUNT = 'mcp-model-test-other';
+
+    /** Dedicated app-DB user so dbappconnect (which rejects empty passwords) can
+     *  reach the test schema for the synchronous DDL the controllers run. */
+    private const DDL_USER = 'kyte_mcp_mt';
+    private const DDL_PASS = 'McpModelTest_123';
+
+    /** Physical tables the write tests create via DDL — dropped on each setUp. */
+    private const TEST_TABLES = [
+        'McpModelTestNew', 'McpModelTestScoped', 'McpModelTestAttr',
+        'McpModelTestDec', 'McpModelTestUpd', 'McpModelTestRen',
+        'McpModelTestRenamed', 'McpModelTestDrop', 'McpModelTestFk',
+        'McpModelTestFkTarget',
+    ];
 
     private Api $api;
     private ModelTools $tools;
@@ -31,22 +56,41 @@ class McpModelToolsTest extends TestCase
     protected function setUp(): void
     {
         \Kyte\Core\DBI::dbInit(KYTE_DB_USERNAME, KYTE_DB_PASSWORD, KYTE_DB_HOST, KYTE_DB_DATABASE, KYTE_DB_CHARSET, 'InnoDB');
+        // Always start on the main connection — a prior test whose DDL threw
+        // before dbswitch()-ing back could otherwise leave us pointed at the
+        // app DB, and the cleanup below (incl. CREATE USER) needs root/main.
+        \Kyte\Core\DBI::$useAppDB = false;
 
         $this->api = new Api();
 
         \Kyte\Core\DBI::createTable(KyteAccount);
         \Kyte\Core\DBI::createTable(Application);
         \Kyte\Core\DBI::createTable(DataModel);
+        \Kyte\Core\DBI::createTable(ModelAttribute);
+
+        // App-DB user for the DDL path (idempotent across runs).
+        \Kyte\Core\DBI::query("CREATE USER IF NOT EXISTS '" . self::DDL_USER . "'@'%' IDENTIFIED BY '" . self::DDL_PASS . "'");
+        \Kyte\Core\DBI::query("GRANT ALL PRIVILEGES ON `" . KYTE_DB_DATABASE . "`.* TO '" . self::DDL_USER . "'@'%'");
+        \Kyte\Core\DBI::query("FLUSH PRIVILEGES");
+
+        // Drop any physical tables left by a prior run before recreating rows.
+        foreach (self::TEST_TABLES as $tbl) {
+            \Kyte\Core\DBI::query("DROP TABLE IF EXISTS `$tbl`");
+        }
 
         \Kyte\Core\DBI::query("DELETE FROM `KyteAccount` WHERE number IN ('" . self::OWN_ACCOUNT . "','" . self::OTHER_ACCOUNT . "')");
         \Kyte\Core\DBI::query("DELETE FROM `Application` WHERE identifier LIKE 'mcp-model-test-%'");
         \Kyte\Core\DBI::query("DELETE FROM `DataModel` WHERE name LIKE 'McpModelTest%'");
+        \Kyte\Core\DBI::query("DELETE FROM `ModelAttribute` WHERE name LIKE 'mcpattr%'");
 
         $this->ownAccountId   = $this->createAccount(self::OWN_ACCOUNT, 'Own');
         $this->otherAccountId = $this->createAccount(self::OTHER_ACCOUNT, 'Other');
 
-        $this->ownAppId   = $this->createApp('mcp-model-test-own',   $this->ownAccountId);
-        $this->otherAppId = $this->createApp('mcp-model-test-other', $this->otherAccountId);
+        // Own app is DDL-capable (points at the test DB via the DDL user) so the
+        // write tools' migrations run. The other app needs no creds — the
+        // foreign-account paths are rejected before any DDL.
+        $this->ownAppId   = $this->createApp('mcp-model-test-own', $this->ownAccountId, true);
+        $this->otherAppId = $this->createApp('mcp-model-test-other', $this->otherAccountId, false);
 
         $wellFormed = json_encode([
             'name'   => 'McpModelTestOwn',
@@ -74,12 +118,27 @@ class McpModelToolsTest extends TestCase
 
         $this->api->account = new \Kyte\Core\ModelObject(KyteAccount);
         $this->api->account->retrieve('id', $this->ownAccountId);
-        $this->api->mcpScopes = ['read'];
+        $this->api->mcpScopes = ['read', 'schema'];
 
         $this->tools = new ModelTools($this->api);
 
         $_SERVER = ['REMOTE_ADDR' => '127.0.0.1'];
     }
+
+    protected function tearDown(): void
+    {
+        // Reset to main and drop the physical tables the write tests created.
+        \Kyte\Core\DBI::$useAppDB = false;
+        foreach (self::TEST_TABLES as $tbl) {
+            try {
+                \Kyte\Core\DBI::query("DROP TABLE IF EXISTS `$tbl`");
+            } catch (\Throwable $e) {
+                // best-effort cleanup
+            }
+        }
+    }
+
+    // ---- read tools -------------------------------------------------------
 
     public function testListModelsReturnsModelsForOwnApp(): void
     {
@@ -127,6 +186,212 @@ class McpModelToolsTest extends TestCase
         $this->assertNull($row);
     }
 
+    // ---- write tools: create_model ---------------------------------------
+
+    public function testCreateModelCreatesTableAndRow(): void
+    {
+        $result = $this->tools->createModel($this->ownAppId, 'McpModelTestNew');
+
+        $this->assertTrue($result['created'], $result['error'] ?? 'create failed');
+        $this->assertSame('McpModelTestNew', $result['model']['name']);
+        $this->assertSame($this->ownAppId, $result['model']['application']);
+        // Physical table exists with the standard primary key.
+        $this->assertSame('int', strtolower(substr((string)$this->appColumnType('McpModelTestNew', 'id'), 0, 3)));
+    }
+
+    public function testCreateModelScopesToCallerAccount(): void
+    {
+        $result = $this->tools->createModel($this->ownAppId, 'McpModelTestScoped');
+        $this->assertTrue($result['created'], $result['error'] ?? 'create failed');
+
+        $dm = new \Kyte\Core\ModelObject(DataModel);
+        $dm->retrieve('id', (int)$result['model']['id']);
+        $this->assertSame($this->ownAccountId, (int)$dm->kyte_account, 'new model must be stamped with the caller account');
+    }
+
+    public function testCreateModelRejectsForeignApplication(): void
+    {
+        $result = $this->tools->createModel($this->otherAppId, 'McpModelTestEvil');
+        $this->assertFalse($result['created'], 'cannot create a model under another account\'s application');
+    }
+
+    // ---- write tools: add_attribute --------------------------------------
+
+    public function testAddAttributeAddsColumn(): void
+    {
+        $modelId = $this->createModelReturningId('McpModelTestAttr');
+
+        $result = $this->tools->addAttribute($modelId, 'mcpattrTitle', 's', size: 255, required: true);
+        $this->assertTrue($result['added'], $result['error'] ?? 'add failed');
+        $this->assertSame('mcpattrTitle', $result['attribute']['name']);
+
+        // Field shows up in the regenerated model definition...
+        $row = $this->tools->readModel($modelId);
+        $this->assertArrayHasKey('mcpattrTitle', $row['definition']['struct']);
+        // ...and as a real column.
+        $this->assertStringStartsWith('varchar', strtolower((string)$this->appColumnType('McpModelTestAttr', 'mcpattrTitle')));
+    }
+
+    public function testAddAttributeDecimalCarriesPrecisionScale(): void
+    {
+        $modelId = $this->createModelReturningId('McpModelTestDec');
+
+        $result = $this->tools->addAttribute($modelId, 'mcpattrPrice', 'd', precision: 10, scale: 2);
+        $this->assertTrue($result['added'], $result['error'] ?? 'add failed');
+        $this->assertSame(10, $result['attribute']['precision']);
+        $this->assertSame(2, $result['attribute']['scale']);
+        // The decimal precision/scale reach the physical column definition.
+        $this->assertSame('decimal(10,2)', strtolower((string)$this->appColumnType('McpModelTestDec', 'mcpattrPrice')));
+    }
+
+    public function testAddAttributeDecimalWithoutPrecisionIsRejected(): void
+    {
+        $modelId = $this->createModelReturningId('McpModelTestDec');
+
+        $result = $this->tools->addAttribute($modelId, 'mcpattrBad', 'd');
+        $this->assertFalse($result['added'], 'a decimal column without precision/scale must be refused');
+    }
+
+    public function testAddAttributeRejectsForeignModel(): void
+    {
+        $result = $this->tools->addAttribute($this->otherModelId, 'mcpattrEvil', 's', size: 50);
+        $this->assertFalse($result['added'], 'cannot add a column to a foreign model');
+    }
+
+    // ---- write tools: update_attribute -----------------------------------
+
+    public function testUpdateAttributeChangesColumn(): void
+    {
+        $modelId = $this->createModelReturningId('McpModelTestUpd');
+        $add = $this->tools->addAttribute($modelId, 'mcpattrOld', 's', size: 100);
+        $attrId = (int)$add['attribute']['id'];
+
+        $result = $this->tools->updateAttribute($attrId, 'mcpattrNew', 'i', unsigned: true);
+        $this->assertTrue($result['updated'], $result['error'] ?? 'update failed');
+        $this->assertSame('mcpattrNew', $result['attribute']['name']);
+        $this->assertSame('i', $result['attribute']['type']);
+
+        $type = strtolower((string)$this->appColumnType('McpModelTestUpd', 'mcpattrNew'));
+        $this->assertStringStartsWith('int', $type);
+        $this->assertStringContainsString('unsigned', $type);
+    }
+
+    public function testUpdateAttributeRejectsForeignAttribute(): void
+    {
+        // An attribute owned by the other account.
+        $foreignAttrId = $this->createModelAttribute('mcpattrForeign', $this->otherModelId, $this->otherAccountId);
+        $result = $this->tools->updateAttribute($foreignAttrId, 'mcpattrHijack', 's', size: 10);
+        $this->assertFalse($result['updated'], 'cannot update a foreign attribute');
+    }
+
+    // ---- write tools: rename_model ---------------------------------------
+
+    public function testRenameModelRenamesTable(): void
+    {
+        $modelId = $this->createModelReturningId('McpModelTestRen');
+
+        $result = $this->tools->renameModel($modelId, 'McpModelTestRenamed');
+        $this->assertTrue($result['renamed'], $result['error'] ?? 'rename failed');
+        $this->assertSame('McpModelTestRenamed', $result['model']['name']);
+
+        // New table exists, old one gone.
+        $this->assertNotNull($this->appColumnType('McpModelTestRenamed', 'id'));
+        $this->assertNull($this->appColumnType('McpModelTestRen', 'id'));
+    }
+
+    public function testRenameModelRejectsForeignModel(): void
+    {
+        $result = $this->tools->renameModel($this->otherModelId, 'McpModelTestRenamed');
+        $this->assertFalse($result['renamed'], 'cannot rename a foreign model');
+    }
+
+    // ---- write tools: remove_attribute (destructive) ---------------------
+
+    public function testRemoveAttributeRequiresConfirmation(): void
+    {
+        $modelId = $this->createModelReturningId('McpModelTestAttr');
+        $add = $this->tools->addAttribute($modelId, 'mcpattrTemp', 's', size: 20);
+        $attrId = (int)$add['attribute']['id'];
+
+        $refused = $this->tools->removeAttribute($attrId);
+        $this->assertFalse($refused['removed'], 'destructive op must be refused without confirm_destructive');
+        // Column still present.
+        $this->assertNotNull($this->appColumnType('McpModelTestAttr', 'mcpattrTemp'));
+
+        $ok = $this->tools->removeAttribute($attrId, true);
+        $this->assertTrue($ok['removed'], $ok['error'] ?? 'remove failed');
+        $this->assertNull($this->appColumnType('McpModelTestAttr', 'mcpattrTemp'), 'column should be dropped');
+    }
+
+    public function testRemoveAttributeRejectsForeignAttribute(): void
+    {
+        $foreignAttrId = $this->createModelAttribute('mcpattrForeign2', $this->otherModelId, $this->otherAccountId);
+        $result = $this->tools->removeAttribute($foreignAttrId, true);
+        $this->assertFalse($result['removed'], 'cannot remove a foreign attribute');
+    }
+
+    // ---- write tools: delete_model (destructive) -------------------------
+
+    public function testDeleteModelRequiresConfirmation(): void
+    {
+        $modelId = $this->createModelReturningId('McpModelTestDrop');
+
+        $refused = $this->tools->deleteModel($modelId);
+        $this->assertFalse($refused['deleted'], 'destructive op must be refused without confirm_destructive');
+        $this->assertNotNull($this->appColumnType('McpModelTestDrop', 'id'), 'table must still exist after a refused delete');
+
+        $ok = $this->tools->deleteModel($modelId, true);
+        $this->assertTrue($ok['deleted'], $ok['error'] ?? 'delete failed');
+        $this->assertNull($this->appColumnType('McpModelTestDrop', 'id'), 'table should be dropped');
+    }
+
+    public function testDeleteModelRejectsForeignModel(): void
+    {
+        $result = $this->tools->deleteModel($this->otherModelId, true);
+        $this->assertFalse($result['deleted'], 'cannot delete a foreign model');
+    }
+
+    public function testDeleteModelBlockedByForeignKeyDependency(): void
+    {
+        $targetId = $this->createModelReturningId('McpModelTestFkTarget');
+        $sourceId = $this->createModelReturningId('McpModelTestFk');
+        // Source.ref -> target (FK). Dropping the target must now be refused.
+        $fk = $this->tools->addAttribute($sourceId, 'mcpattrRef', 'i', foreign_key_model: $targetId);
+        $this->assertTrue($fk['added'], $fk['error'] ?? 'fk add failed');
+
+        $result = $this->tools->deleteModel($targetId, true);
+        $this->assertFalse($result['deleted'], 'a model referenced by another model\'s FK must not be droppable');
+        // The FK guard fires before any DROP — target still present.
+        $this->assertNotNull($this->appColumnType('McpModelTestFkTarget', 'id'));
+    }
+
+    // ---- helpers ----------------------------------------------------------
+
+    private function createModelReturningId(string $name): int
+    {
+        $result = $this->tools->createModel($this->ownAppId, $name);
+        $this->assertTrue($result['created'], $result['error'] ?? "failed to create $name");
+        return (int)$result['model']['id'];
+    }
+
+    /**
+     * SHOW COLUMNS for a column on the app (test) DB; null when the column or
+     * table is absent. Returns the column Type string (e.g. "decimal(10,2)").
+     */
+    private function appColumnType(string $table, string $column): ?string
+    {
+        \Kyte\Core\Api::dbappconnect(KYTE_DB_DATABASE, self::DDL_USER, self::DDL_PASS, KYTE_DB_HOST);
+        \Kyte\Core\Api::dbswitch(true);
+        try {
+            $rows = \Kyte\Core\DBI::query("SHOW COLUMNS FROM `$table` LIKE '$column'");
+        } catch (\Throwable $e) {
+            $rows = [];
+        } finally {
+            \Kyte\Core\Api::dbswitch();
+        }
+        return $rows[0]['Type'] ?? null;
+    }
+
     private function createAccount(string $number, string $name): int
     {
         $obj = new \Kyte\Core\ModelObject(KyteAccount);
@@ -134,14 +399,21 @@ class McpModelToolsTest extends TestCase
         return (int)$obj->id;
     }
 
-    private function createApp(string $identifier, int $accountId): int
+    private function createApp(string $identifier, int $accountId, bool $withDb): int
     {
-        $obj = new \Kyte\Core\ModelObject(Application);
-        $obj->create([
+        $data = [
             'name'         => 'App ' . $identifier,
             'identifier'   => $identifier,
             'kyte_account' => $accountId,
-        ]);
+        ];
+        if ($withDb) {
+            $data['db_name']     = KYTE_DB_DATABASE;
+            $data['db_username'] = self::DDL_USER;
+            $data['db_password'] = self::DDL_PASS;
+            $data['db_host']     = KYTE_DB_HOST;
+        }
+        $obj = new \Kyte\Core\ModelObject(Application);
+        $obj->create($data);
         return (int)$obj->id;
     }
 
@@ -153,6 +425,19 @@ class McpModelToolsTest extends TestCase
             'application'      => $appId,
             'model_definition' => $definition,
             'kyte_account'     => $accountId,
+        ]);
+        return (int)$obj->id;
+    }
+
+    private function createModelAttribute(string $name, int $modelId, int $accountId): int
+    {
+        $obj = new \Kyte\Core\ModelObject(ModelAttribute);
+        $obj->create([
+            'name'         => $name,
+            'type'         => 's',
+            'size'         => 50,
+            'dataModel'    => $modelId,
+            'kyte_account' => $accountId,
         ]);
         return (int)$obj->id;
     }


### PR DESCRIPTION
## KYTE-#325 — PR B (MCP schema-management tools)

Builds on PR A (#108). Lets a `schema`-scoped MCP token create and migrate data models from Claude, where each change applies a **real DDL migration** via `DataModelController`/`ModelAttributeController` in internal mode (mirrors the #322 `SiteTools` pattern).

### New scope
- `schema` added to `KyteMCPTokenController::VALID_SCOPES`, held separately from `provision` (model-migration rights independent of site spin-up/tear-down). Not hierarchical.

### New tools (`ModelTools`, all `#[RequiresScope('schema')]`)
| tool | DDL | notes |
|------|-----|-------|
| `create_model` | CREATE TABLE | base table w/ PK + audit columns |
| `add_attribute` | ADD COLUMN | decimal needs precision+scale; varchar needs size; FK via `foreign_key_model` |
| `update_attribute` | CHANGE COLUMN | `name` required (full column def rewritten) |
| `rename_model` | RENAME TABLE | loads app model constants first (see below) |
| `remove_attribute` | DROP COLUMN | **destructive** — requires `confirm_destructive=true` |
| `delete_model` | DROP TABLE | **destructive** — requires `confirm_destructive=true` |

Every caller-supplied model/attribute id is re-scoped to the token's account; foreign ids are rejected. `read_model`/`list_models` already existed.

### Why `rename_model` calls `loadAppModels`
`DataModelController::update` guards on `defined($o->name)` — the model must be registered as a runtime constant. The HTTP pipeline does this via `Api::loadAppModels` at routing, but the MCP path bypasses routing, so the tool registers the app's models first (same as `AppModelWrapperController`).

### Model-layer hardening (surfaced by partial MCP payloads)
- `DataModelController::prepareModelDef` reads optional flags/defaults defensively — no undefined-property warning / null-to-strlen deprecation when a caller omits `protected`/`password`/`defaults`/`unsigned`.
- `Api::loadAppModels` skips rows with a missing/corrupt `model_definition` (instead of `define()`-ing a null name) and no longer re-defines an already-defined constant.

### Tests
`McpModelToolsTest` extended with write coverage: create / add / update / rename, **decimal precision/scale reaching the physical column**, destructive-op confirm gating, **FK-dependency block**, and cross-account isolation — driving real DDL against the test DB via a dedicated password-bearing app user (`Api::dbappconnect` rejects empty passwords).

### Verification
- PHPStan level 1 (`php:8.2-cli`, `-d memory_limit=512M`) — **green**.
- Unit suite (256 tests) — **green** against MariaDB 10.5.

### Follow-ups (not in this PR)
- dev dogfood: grant `schema` on dev token #8 once deployed to dev19.
- Release v4.15.x (rides with the batched v4.14.0 site-tools rollout).
- Shipyard token-UI scope checkboxes (read/draft/commit/provision/schema) = Shipyard 2.2.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)