### PR TITLE
fix(migration): ensure kyte_locked column on DataModel + ModelAttribute (KYTE-#325)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,12 @@ A `schema`-scoped MCP token can now create and migrate data models from Claude, 
 **PR A — model-layer fixes/hardening (platform; benefits Shipyard too):**
 - **`DBI::renameTable`** referenced an undefined `$tbl_name_news` (typo) → emitted a malformed RENAME; rename was effectively broken. Fixed to `$tbl_name_new`.
 - **`DBI::dropTable`** now uses `DROP TABLE IF EXISTS` (was a bare DROP that errored on an already-absent table).
-- **`kyte_locked` enforced on the DDL path** — `DataModelController`/`ModelAttributeController` now refuse update/delete of a locked model or attribute, guarding before any DB switch or DDL.
+- **`kyte_locked` enforced on the DDL path** — `DataModelController`/`ModelAttributeController` now refuse update/delete of a locked model or attribute, guarding before any DB switch or DDL. New `migrations/4.15.0_datamodel_kyte_locked.sql` (idempotent `ADD COLUMN IF NOT EXISTS`) guarantees the column exists on both `DataModel` and `ModelAttribute` — the original consolidated 3.x→4.8 upgrade added it but some installs applied it only partially (observed: `ModelAttribute` had it, `DataModel` did not), leaving the model-level guard silently inert. The guard is only meaningful when the column physically exists.
 - **FK-dependency guard before drop** — dropping a model is refused while another model's attribute references it via `foreignKeyModel`; dropping a column is refused while another attribute references it via `foreignKeyAttribute`. Both account-scoped, with an error naming the blocking `model.attribute`. Replaces the two stale "external tables and foreign keys" TODOs.
 - **Decimal (`d`) support** — new `migrations/4.15.0_modelattribute_decimal.sql` adds `precision`/`scale` to `ModelAttribute`; `prepareModelDef` passes them through for type `d`; `DBI::buildFieldDefinition` now throws on a `d` column missing precision/scale instead of emitting invalid SQL. The type was previously non-functional end-to-end.
 - **Model-cache invalidation** — both controllers call `Api::clearModelCache()` after a schema change (create/rename/delete model, add/change/drop column), so the new struct is served immediately instead of the stale file cache (up to 1h TTL).
 
-**Migration:** `migrations/4.15.0_modelattribute_decimal.sql` (additive, nullable, no-op for existing rows). Rolls with the batched 4.14.0 site-tools rollout.
+**Migrations:** `migrations/4.15.0_modelattribute_decimal.sql` (adds `precision`/`scale`) and `migrations/4.15.0_datamodel_kyte_locked.sql` (ensures `kyte_locked` on `DataModel` + `ModelAttribute`). Both additive, nullable, idempotent, no-op for existing rows. Roll with the batched 4.14.0 site-tools rollout.
 
 ## 4.14.0
 

--- a/migrations/4.15.0_datamodel_kyte_locked.sql
+++ b/migrations/4.15.0_datamodel_kyte_locked.sql
@@ -1,0 +1,31 @@
+-- =========================================================================
+-- Kyte v4.15.0 - Ensure `kyte_locked` on DataModel + ModelAttribute (KYTE-#325)
+-- =========================================================================
+-- IMPORTANT: Backup your database before running this migration.
+--
+-- v4.15.0 enforces `kyte_locked` on the DDL path: DataModelController and
+-- ModelAttributeController refuse update/delete of a locked model/attribute.
+-- That guard reads `kyte_locked` off the row, so it is only meaningful when
+-- the column physically exists. The original consolidated 3.x->4.8 upgrade
+-- added it, but some installs applied it only partially (observed in the wild:
+-- ModelAttribute had the column while DataModel did not), which left the new
+-- model-level lock guard silently inert (read as NULL -> 0 -> "not locked").
+--
+-- This migration GUARANTEES the column exists on both framework tables so the
+-- lock guard is reliable on every install. Idempotent (IF NOT EXISTS),
+-- nullable, default 0 -> a no-op for existing rows and for installs that
+-- already have it.
+--
+-- ADDITIVE / migration-first / inert on older code. PascalCase tables.
+-- MariaDB `ALTER ... ADD COLUMN IF NOT EXISTS` (matches existing migrations).
+--
+-- See src/Mvc/Controller/DataModelController.php and
+-- src/Mvc/Controller/ModelAttributeController.php (kyte_locked guards),
+-- src/Mvc/Model/DataModel.php / src/Mvc/Model/ModelAttribute.php (definitions).
+-- =========================================================================
+
+ALTER TABLE `DataModel`
+    ADD COLUMN IF NOT EXISTS `kyte_locked` INT UNSIGNED NULL DEFAULT 0;
+
+ALTER TABLE `ModelAttribute`
+    ADD COLUMN IF NOT EXISTS `kyte_locked` INT UNSIGNED NULL DEFAULT 0;


### PR DESCRIPTION
## What

Adds `migrations/4.15.0_datamodel_kyte_locked.sql` — an idempotent `ADD COLUMN IF NOT EXISTS kyte_locked` on **both** `DataModel` and `ModelAttribute`.

## Why

v4.15.0 (PR #108) introduced the **`kyte_locked` enforcement** on the DDL path — `DataModelController`/`ModelAttributeController` refuse update/delete of a locked model/attribute. That guard reads `kyte_locked` off the row, so it is only meaningful when the column physically exists.

During the **#325 dev dogfood** I found dev19's control DB had `ModelAttribute.kyte_locked` but **not** `DataModel.kyte_locked` — the original consolidated 3.x→4.8 upgrade was applied only partially. Effect: the model-level lock guard was **silently inert** (read as `NULL → 0 → "not locked"`). `create_model` still worked because Kyte only writes physically-existing columns, so the drift was invisible until the guard was exercised.

Since v4.15.0 is the release that *introduces* this guard, its migration should **guarantee** the column exists on every install — otherwise the feature is silently broken on any drifted client DB.

## Notes

- Idempotent (`IF NOT EXISTS`), nullable, `DEFAULT 0` → no-op for existing rows and for installs that already have the column (matches the established MariaDB migration convention used elsewhere in `migrations/`).
- Migration-only; no code change. Rolls with the batched 4.14.0 + 4.15.0 rollout.
- Validated: applied to dev19 manually during the dogfood, after which the lock guard correctly refused rename/update/delete on a locked model/attribute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)