### PR TITLE
fix(migration): make kyte_locked migration portable to MySQL (v4.15.1, KYTE-#325)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 4.15.1
+
+### Fix: make the `kyte_locked` migration portable to MySQL — KYTE-#325
+
+- `migrations/4.15.0_datamodel_kyte_locked.sql` used MariaDB-only `ALTER TABLE ... ADD COLUMN IF NOT EXISTS`, which is a **syntax error on MySQL 5.7 / 8.0**. Rewritten to guard with an `information_schema` column check + a prepared statement, which is idempotent on **both MySQL and MariaDB**. Surfaced during the v4.15.0 rollout to the first MySQL-backed install (its `kyte_locked` columns already existed, so nothing was harmed — the failed statement was a no-op — but a *drifted* MySQL install would have errored and never gained the column, leaving the model-level lock guard inert).
+- Migration-only change; no PHP behavior change. Installs already on v4.15.0 with the columns present need no action. Fresh or drifted MySQL installs now apply cleanly.
+
 ## 4.15.0
 
 ### Feature: MCP schema-management tools (create/alter/drop models) + `schema` scope — KYTE-#325

--- a/migrations/4.15.0_datamodel_kyte_locked.sql
+++ b/migrations/4.15.0_datamodel_kyte_locked.sql
@@ -12,20 +12,49 @@
 -- model-level lock guard silently inert (read as NULL -> 0 -> "not locked").
 --
 -- This migration GUARANTEES the column exists on both framework tables so the
--- lock guard is reliable on every install. Idempotent (IF NOT EXISTS),
--- nullable, default 0 -> a no-op for existing rows and for installs that
--- already have it.
+-- lock guard is reliable on every install. It is idempotent (adds the column
+-- only when absent), nullable, default 0 -> a no-op for existing rows and for
+-- installs that already have it.
+--
+-- PORTABILITY (v4.15.1 fix): earlier this used MariaDB-only
+-- `ALTER TABLE ... ADD COLUMN IF NOT EXISTS`, which is a syntax error on MySQL
+-- (5.7 / 8.0). It now guards with an information_schema check + a prepared
+-- statement, which is idempotent on BOTH MySQL and MariaDB. Safe to (re-)run
+-- on any install regardless of engine or prior state.
 --
 -- ADDITIVE / migration-first / inert on older code. PascalCase tables.
--- MariaDB `ALTER ... ADD COLUMN IF NOT EXISTS` (matches existing migrations).
 --
 -- See src/Mvc/Controller/DataModelController.php and
 -- src/Mvc/Controller/ModelAttributeController.php (kyte_locked guards),
 -- src/Mvc/Model/DataModel.php / src/Mvc/Model/ModelAttribute.php (definitions).
 -- =========================================================================
 
-ALTER TABLE `DataModel`
-    ADD COLUMN IF NOT EXISTS `kyte_locked` INT UNSIGNED NULL DEFAULT 0;
+-- DataModel.kyte_locked
+SET @col_exists := (
+    SELECT COUNT(*) FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME   = 'DataModel'
+      AND COLUMN_NAME  = 'kyte_locked'
+);
+SET @ddl := IF(@col_exists = 0,
+    'ALTER TABLE `DataModel` ADD COLUMN `kyte_locked` INT UNSIGNED NULL DEFAULT 0',
+    'DO 0'
+);
+PREPARE stmt FROM @ddl;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
 
-ALTER TABLE `ModelAttribute`
-    ADD COLUMN IF NOT EXISTS `kyte_locked` INT UNSIGNED NULL DEFAULT 0;
+-- ModelAttribute.kyte_locked
+SET @col_exists := (
+    SELECT COUNT(*) FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME   = 'ModelAttribute'
+      AND COLUMN_NAME  = 'kyte_locked'
+);
+SET @ddl := IF(@col_exists = 0,
+    'ALTER TABLE `ModelAttribute` ADD COLUMN `kyte_locked` INT UNSIGNED NULL DEFAULT 0',
+    'DO 0'
+);
+PREPARE stmt FROM @ddl;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;


### PR DESCRIPTION
## What
Rewrites `migrations/4.15.0_datamodel_kyte_locked.sql` to be **engine-portable** (MySQL + MariaDB), replacing the MariaDB-only `ADD COLUMN IF NOT EXISTS` with an `information_schema` guard + prepared statement. Ships as **v4.15.1**.

## Why
The migration (added in #111) used `ALTER TABLE ... ADD COLUMN IF NOT EXISTS`, which is **MariaDB-only** — it's a **syntax error on MySQL 5.7/8.0**. This surfaced during the v4.15.0 rollout to the first MySQL-backed install (ETOM, MySQL 8.0.44).

- **No install was harmed:** ETOM's `kyte_locked` columns already existed, so the failed statement was a no-op, and the decimal migration (portable) succeeded. The MariaDB clients applied the original fine.
- **But it was latently broken:** a *drifted* MySQL install would have errored and never gained the column, leaving the v4.15.0 model-level lock guard inert — the opposite of the migration's purpose.

## Fix
Idempotent, portable pattern:
```sql
SET @col_exists := (SELECT COUNT(*) FROM information_schema.COLUMNS
    WHERE TABLE_SCHEMA=DATABASE() AND TABLE_NAME='DataModel' AND COLUMN_NAME='kyte_locked');
SET @ddl := IF(@col_exists=0, 'ALTER TABLE `DataModel` ADD COLUMN `kyte_locked` INT UNSIGNED NULL DEFAULT 0', 'DO 0');
PREPARE stmt FROM @ddl; EXECUTE stmt; DEALLOCATE PREPARE stmt;
```
(repeated for `ModelAttribute`).

## Validation
Ran the new pattern live against both engines — clean, exit 0, columns intact:
- **MySQL 8.0.44** (ETOM `shipyard`) — the engine that rejected the old syntax
- **MariaDB 11.8.6** (dev)

## Impact
Migration-only; **no PHP change**. Installs already on v4.15.0 with the columns present need no action — the deployed clients do **not** require re-rolling. Protects future/fresh/drifted MySQL installs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)