### PR TITLE
feat(190): column projection in the query engine (P1 slice 1)

### DIFF
--- a/src/Core/DBI.php
+++ b/src/Core/DBI.php
@@ -1202,9 +1202,33 @@ class DBI {
 	 * @param integer $id
 	 * @param string $condition
 	 */
-	public static function select($table, $id = null, $condition = null, $join = null)
+	public static function select($table, $id = null, $condition = null, $join = null, $fields = null)
 	{
 		$cacheKey = null;
+
+		// Column projection (KYTE-#190): when $fields is a non-empty array of
+		// column names, read only those columns instead of `table`.* — this is
+		// how large TEXT/BLOB columns are kept out of list reads. Backward
+		// compatible: null (the default) preserves the historical SELECT *.
+		// Column names are validated against a strict identifier pattern (they
+		// originate from the model struct, but we never interpolate anything
+		// unvalidated into SQL). `id` is always included so every projected row
+		// stays identifiable/hydratable. An empty-after-validation list falls
+		// back to * rather than emitting invalid SQL.
+		$columnList = "`$table`.*";
+		if (is_array($fields) && count($fields) > 0) {
+			$cols = [];
+			$seen = [];
+			foreach (array_merge(['id'], $fields) as $f) {
+				if (is_string($f) && preg_match('/^[A-Za-z0-9_]+$/', $f) && !isset($seen[$f])) {
+					$seen[$f] = true;
+					$cols[] = "`$table`.`$f`";
+				}
+			}
+			if (count($cols) > 0) {
+				$columnList = implode(', ', $cols);
+			}
+		}
 
 		// Check cache if enabled
 		if (self::$cacheEnabled) {
@@ -1213,6 +1237,7 @@ class DBI {
 				'id' => $id,
 				'condition' => $condition,
 				'join' => $join,
+				'columns' => $columnList,
 				'db' => self::$useAppDB ? 'app' : 'main'
 			]));
 
@@ -1228,7 +1253,7 @@ class DBI {
 		// db connection
 		$con = self::getConnection();
 
-		$query = "SELECT `$table`.* FROM `$table`";
+		$query = "SELECT $columnList FROM `$table`";
 
 		if (is_array($join)) {
 			foreach ($join as $j) {

--- a/src/Core/Model.php
+++ b/src/Core/Model.php
@@ -29,6 +29,15 @@ class Model
 	 */
 	private $eagerLoad = [];
 
+	/**
+	 * Column projection (KYTE-#190). When set to a non-empty array of column
+	 * names, retrieve() reads only those columns (plus `id`) instead of every
+	 * column — the mechanism for keeping large TEXT/BLOB columns out of list
+	 * reads. null (the default) preserves the historical SELECT * behaviour.
+	 * @var array|null
+	 */
+	private $projection = null;
+
 	public function __construct($model, $page_size = null, $page_num = null, $search_fields = null, $search_value = null) {
 		$this->kyte_model = $model;
 		$this->page_size = $page_size;
@@ -54,6 +63,26 @@ class Model
 			$this->eagerLoad[] = $relations;
 		} elseif (is_array($relations)) {
 			$this->eagerLoad = array_merge($this->eagerLoad, $relations);
+		}
+		return $this;  // Fluent interface for chaining
+	}
+
+	/**
+	 * Restrict retrieve() to a subset of columns (KYTE-#190 column projection).
+	 * `id` is always included by the query layer so rows stay identifiable.
+	 * Pass a single field name or an array of field names. Passing null/empty
+	 * clears the projection (back to all columns).
+	 *
+	 * @param string|array|null $fields Column name(s) from the model struct
+	 * @return self For method chaining
+	 */
+	public function select($fields) {
+		if (is_string($fields)) {
+			$this->projection = [$fields];
+		} elseif (is_array($fields) && count($fields) > 0) {
+			$this->projection = $fields;
+		} else {
+			$this->projection = null;
 		}
 		return $this;  // Fluent interface for chaining
 	}
@@ -275,7 +304,7 @@ class Model
 				}
 			}
 
-			$data = \Kyte\Core\DBI::select($this->kyte_model['name'], null, $sql, $join);
+			$data = \Kyte\Core\DBI::select($this->kyte_model['name'], null, $sql, $join, $this->projection);
 
 			foreach ($data as $item) {
 				$obj = new \Kyte\Core\ModelObject($this->kyte_model);

--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -152,6 +152,26 @@ class ModelTest extends TestCase
         $data = \Kyte\Core\DBI::query('SELECT * FROM `TestTable`;');
         $this->assertTrue(count($data) > 0 ? true : false);
 
+        // test column projection (KYTE-#190): DBI::select with a field list
+        // reads only the requested columns (plus `id`, always included),
+        // keeping large/other columns out of the result set.
+        $projected = \Kyte\Core\DBI::select('TestTable', null, null, null, ['name']);
+        $this->assertNotEmpty($projected);
+        $this->assertArrayHasKey('id', $projected[0]);              // id auto-included
+        $this->assertArrayHasKey('name', $projected[0]);            // requested column
+        $this->assertArrayNotHasKey('temperature', $projected[0]);  // projected out
+        $this->assertArrayNotHasKey('category', $projected[0]);     // projected out
+        // backward compatible: no field list still returns every column
+        $full = \Kyte\Core\DBI::select('TestTable');
+        $this->assertArrayHasKey('temperature', $full[0]);
+        // an empty / all-invalid field list falls back to SELECT * (never emits
+        // invalid SQL), and an injection-y column name is dropped
+        $fallback = \Kyte\Core\DBI::select('TestTable', null, null, null, []);
+        $this->assertArrayHasKey('temperature', $fallback[0]);
+        $sanitized = \Kyte\Core\DBI::select('TestTable', null, null, null, ['name', 'temperature; DROP TABLE x']);
+        $this->assertArrayHasKey('name', $sanitized[0]);
+        $this->assertArrayNotHasKey('temperature', $sanitized[0]); // malformed name dropped
+
         // test udpate entry
         $model = new \Kyte\Core\ModelObject(TestTable);
         $this->assertTrue($model->retrieve('name', 'Test'));
@@ -233,6 +253,17 @@ class ModelTest extends TestCase
         $model = new \Kyte\Core\Model(TestTable);
         $this->assertTrue($model->retrieve('category', 'Test'));
         $this->assertEquals(2, $model->count());
+
+        // test Model column projection (KYTE-#190 fluent select): projected
+        // rows hydrate the requested column but not the omitted ones.
+        $model = new \Kyte\Core\Model(TestTable);
+        $this->assertTrue($model->select(['name'])->retrieve('category', 'Test'));
+        $this->assertEquals(2, $model->count());
+        $projObj = $model->first();
+        $this->assertIsObject($projObj);
+        $this->assertNotFalse($projObj->getParam('name'));        // projected column present
+        $this->assertNotFalse($projObj->getParam('id'));          // id always included
+        $this->assertFalse($projObj->getParam('temperature'));    // omitted column not hydrated
 
         // test retrieve with conditions
         $model = new \Kyte\Core\Model(TestTable);


### PR DESCRIPTION
First slice of **KYTE-#190** Part A/P1 (see `docs/design/datamodel-layer-optimization.md`).

## What
Adds an opt-in **column-projection** capability to the read path so large `TEXT`/`BLOB` columns can be kept out of list reads — the core mechanism behind the OOM/scan risk that hit KyteActivityLog (#182) and equally affects user-designed models.

- **`DBI::select()`** gains an optional `$fields` param (5th, appended → back-compat). A non-empty array reads only those columns (plus `id`, always included so rows stay identifiable/hydratable). Column names are validated against a strict identifier pattern; an empty/all-invalid list falls back to `SELECT *` (never emits invalid SQL). The projected column list is folded into the query cache key.
- **`Model`** gains a `$projection` property + a fluent **`select()`** method (mirrors the existing `with()`), threaded into `DBI::select` in `retrieve()`.
- **Fully backward compatible:** `null` projection (the default) preserves the historical `SELECT *` for every existing caller.

## Why it's safe
`populate()` only hydrates columns present in the returned row, so projected/partial rows work without touching any consumer. No existing call site changes behavior.

## Validation
- **Full unit suite green: 256 tests / 782 assertions** against MariaDB 10.5 (`tests/docker-compose.test.yml`).
- PHPStan clean (level 1 + baseline).
- New `ModelTest` coverage: DBI-level projection (id auto-include, columns projected out, `SELECT *` fallback, malformed-column-name sanitization) and Model fluent `select()` (projected column hydrated, omitted column not).

## Not in this slice (next)
Deferred/lazy large columns, pagination guardrails (incl. the `page_num=0` unbounded-list fix), and retro-fitting `KyteActivityLogController` onto real projection. CHANGELOG/version bump deferred until P1 is release-ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)