### PR TITLE
feat(190): lazy-load deferred columns via ModelObject::load() (P1 slice 2)

### DIFF
--- a/src/Core/ModelObject.php
+++ b/src/Core/ModelObject.php
@@ -216,6 +216,58 @@ class ModelObject
 	}
 
 	/**
+	 * Lazy-load additional column(s) onto an already-retrieved object
+	 * (KYTE-#190). Pairs with column projection: retrieve a list with a narrow
+	 * Model::select([...]) and then load() the large/deferred columns only for
+	 * the specific object(s) that actually need them — keeping big TEXT/BLOB
+	 * columns out of list reads without losing access to them on demand.
+	 *
+	 * Requires the object to have been retrieved (must have an id). Only real
+	 * struct columns are loaded; unknown names are ignored. Fetches the
+	 * requested columns for this row in a single projected query and populates
+	 * them (refreshing any already-set values).
+	 *
+	 * @param string|array $fields Column name(s) to load
+	 * @return bool true if the columns were loaded, false if the object has no
+	 *              id, nothing valid was requested, or the row was not found
+	 */
+	public function load($fields)
+	{
+		$id = isset($this->id) ? $this->id : null;
+		if (!isset($id)) {
+			return false;
+		}
+
+		$cols = is_array($fields) ? $fields : [$fields];
+		$cols = array_values(array_filter($cols, function ($c) {
+			return is_string($c) && array_key_exists($c, $this->kyte_model['struct']);
+		}));
+		if (count($cols) === 0) {
+			return false;
+		}
+
+		// check db context
+		if (isset($this->kyte_model['appId'])) {
+			\Kyte\Core\Api::dbswitch(true);
+		} else {
+			\Kyte\Core\Api::dbswitch();
+		}
+
+		$data = \Kyte\Core\DBI::select($this->kyte_model['name'], (int)$id, null, null, $cols);
+		if (count($data) === 0) {
+			return false;
+		}
+
+		foreach ($data[0] as $key => $value) {
+			if (array_key_exists($key, $this->kyte_model['struct'])) {
+				$this->setParam($key, $value);
+			}
+		}
+
+		return true;
+	}
+
+	/**
      * Update entry information for item that was retrieved.
      *
      * @param array $params

--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -265,6 +265,11 @@ class ModelTest extends TestCase
         $this->assertNotFalse($projObj->getParam('id'));          // id always included
         $this->assertFalse($projObj->getParam('temperature'));    // omitted column not hydrated
 
+        // test lazy-load of a projected-out column (KYTE-#190 ModelObject::load)
+        $this->assertTrue($projObj->load('temperature'));         // load it on demand
+        $this->assertNotFalse($projObj->getParam('temperature')); // now populated
+        $this->assertFalse($projObj->load('does_not_exist'));     // unknown column = no-op
+
         // test retrieve with conditions
         $model = new \Kyte\Core\Model(TestTable);
         $this->assertTrue($model->retrieve('category', 'Test', false, [['field' => 'name', 'value' => 'Test2']]));


### PR DESCRIPTION
Second slice of **KYTE-#190** Part A/P1, building on the column-projection primitive (#114).

## What
Adds **`ModelObject::load($fields)`** — fetch large/deferred columns on demand for an already-retrieved object.

Pairs with projection: retrieve a list with a narrow `Model::select([...])` to keep `TEXT`/`BLOB` columns out of the list read, then `load()` those columns only for the specific object(s) that actually need them.

- Requires the object to have an `id`; fetches only real struct columns in a **single projected query** (`DBI::select` with `$id` + `$fields`) and populates them (refreshing any set values).
- Unknown/invalid column names and id-less objects are safe **no-ops** (return `false`).
- **Purely additive** — no default behavior change, no `getParam()` semantic change.

## Validation
- `ModelTest` green (**74 assertions**) against MariaDB 10.5 — loads a projected-out column on demand and asserts it becomes populated; unknown-column load is a no-op.
- PHPStan clean.

## Not in this slice (next)
- **Pagination guardrails** (the `page_num=0` unbounded-list fix + max page-size) — has a default-cap **policy** decision for the brainstorm.
- **Retro-fit `KyteActivityLogController`** onto real projection.
- A Model-level batch `load()` (load a column for a whole result set in one query) is a candidate follow-up to avoid N+1 when a deferred column is needed list-wide.

Refs #190.

🤖 Generated with [Claude Code](https://claude.com/claude-code)