### PR TITLE
feat(190): generic ModelController projection wiring + activity-log retrofit (P1 slice 4)

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -25,6 +25,7 @@
       <file>tests/McpSiteToolsTest.php</file>
       <file>tests/McpTokenControllerTest.php</file>
       <file>tests/McpTokenStrategyTest.php</file>
+      <file>tests/ModelControllerProjectionTest.php</file>
       <file>tests/ModelTest.php</file>
       <file>tests/PublishIntegrityTest.php</file>
       <file>tests/RefreshTokenStoreTest.php</file>

--- a/src/Mvc/Controller/KyteActivityLogController.php
+++ b/src/Mvc/Controller/KyteActivityLogController.php
@@ -44,6 +44,19 @@ class KyteActivityLogController extends ModelController
     }
 
     /**
+     * KYTE-#190: keep the heavy LONGTEXT columns (request_data, changes) out of
+     * LIST reads at the QUERY level — they are never read from the DB for a
+     * list, superseding the old #182 post-query unset. The single-record detail
+     * fetch (by id) still returns them for decoding. `$isDetailView` is set in
+     * hook_prequery, which runs before the read.
+     *
+     * @return array<int,string>
+     */
+    protected function defaultProjectionExclude() {
+        return $this->isDetailView ? [] : ['request_data', 'changes'];
+    }
+
+    /**
      * Filter support via custom headers and query params
      *
      * Supported filters:
@@ -190,13 +203,12 @@ class KyteActivityLogController extends ModelController
             $r['action_color'] = self::ACTION_COLORS[$o->action] ?? '#6c757d';
         }
 
-        // List projection (KYTE-#182): the heavy LONGTEXT columns are only
-        // consumed by the single-record detail view. On a list response, drop
-        // the raw blobs and skip the decode entirely so a page of rows can't
-        // pull a request body per row into memory. The detail fetch (by id)
-        // still returns the decoded payload below.
+        // List projection (KYTE-#190, supersedes the #182 post-query prune):
+        // the heavy LONGTEXT columns are excluded at the QUERY level via
+        // defaultProjectionExclude(), so on a list read they were never read
+        // from the DB — nothing to decode. The detail fetch (by id) returns
+        // them for decoding below.
         if (!$this->isDetailView) {
-            unset($r['request_data'], $r['changes']);
             return;
         }
 

--- a/src/Mvc/Controller/ModelController.php
+++ b/src/Mvc/Controller/ModelController.php
@@ -229,6 +229,86 @@ class ModelController
         $this->hook_auth();
     }
 
+    /**
+     * Resolve the column projection for a read (KYTE-#190). Returns the list of
+     * columns to SELECT, or null for "all columns" (historical behaviour).
+     *
+     *   - a non-empty X-Kyte-Fields value => those columns (a dotted FK path
+     *     like `client.name` contributes its base column `client`) unioned with
+     *     the always-include set;
+     *   - else a non-empty default-exclude set => all struct columns minus the
+     *     excludes (server-side deferral of e.g. large LONGTEXT columns);
+     *   - else null.
+     *
+     * Pure/logic-only (no DB, no request state) so it is unit-testable. A
+     * header that names nothing valid falls back to null (full row) rather than
+     * an empty/invalid projection.
+     *
+     * @param array<string,mixed> $struct      Model struct (column => definition)
+     * @param string|null         $headerValue Raw X-Kyte-Fields header value
+     * @param array<int,string>   $always      Always-included columns
+     * @param array<int,string>   $exclude     Columns excluded by default
+     * @return array<int,string>|null
+     */
+    public static function resolveProjection($struct, $headerValue, array $always, array $exclude)
+    {
+        if (is_string($headerValue) && trim($headerValue) !== '') {
+            $requested = [];
+            foreach (explode(',', $headerValue) as $f) {
+                $f = trim($f);
+                if ($f === '') {
+                    continue;
+                }
+                // dotted FK path (client.name) contributes its base column (client)
+                $dot = strpos($f, '.');
+                $root = $dot !== false ? substr($f, 0, $dot) : $f;
+                if (isset($struct[$root])) {
+                    $requested[$root] = true;
+                }
+            }
+            if (!empty($requested)) {
+                return array_values(array_unique(array_merge($always, array_keys($requested))));
+            }
+            return null; // header present but nothing valid => full row (safe)
+        }
+
+        if (!empty($exclude)) {
+            return array_values(array_diff(array_keys($struct), $exclude));
+        }
+
+        return null;
+    }
+
+    /**
+     * Columns always kept in a projected read (KYTE-#190) regardless of the
+     * client's X-Kyte-Fields request: id + account/audit columns, plus anything
+     * a subclass needs for its response hooks. Filtered to columns that exist in
+     * the model struct. Override to add controller-specific required columns.
+     *
+     * @return array<int,string>
+     */
+    protected function projectionAlwaysInclude()
+    {
+        $always = ['id', 'kyte_account', 'created_by', 'date_created', 'modified_by', 'date_modified', 'deleted_by', 'date_deleted', 'deleted'];
+        $struct = $this->model['struct'];
+        return array_values(array_filter($always, function ($c) use ($struct) {
+            return isset($struct[$c]);
+        }));
+    }
+
+    /**
+     * Columns a controller excludes from reads by default when the client sends
+     * no explicit X-Kyte-Fields projection (KYTE-#190) — e.g. large LONGTEXT
+     * columns a list view never needs. Empty by default (no server-side
+     * deferral).
+     *
+     * @return array<int,string>
+     */
+    protected function defaultProjectionExclude()
+    {
+        return [];
+    }
+
     protected function getObject($obj) {
         try {
             $response = $obj->getAllParams();
@@ -703,8 +783,21 @@ class ModelController
                 error_log("HTTP_X_KYTE_PAGE_SEARCH_VALUE: ".$_SERVER['HTTP_X_KYTE_PAGE_SEARCH_VALUE']."; Decoded: ".$search_values);
             }
 
+            // Column projection (KYTE-#190): resolve the SELECT column list from
+            // the client's X-Kyte-Fields header (opt-in) or a controller's
+            // default-exclude set, else null (full row — historical behaviour).
+            $projection = self::resolveProjection(
+                $this->model['struct'],
+                isset($_SERVER['HTTP_X_KYTE_FIELDS']) ? $_SERVER['HTTP_X_KYTE_FIELDS'] : null,
+                $this->projectionAlwaysInclude(),
+                $this->defaultProjectionExclude()
+            );
+
             // init model
             $objs = new \Kyte\Core\Model($this->model, $this->api->page_size, $this->api->page_num, $search_fields, $search_values);
+            if ($projection !== null) {
+                $objs->select($projection);
+            }
             $objs->retrieve($field, $value, $isLike, $conditions, $all, $order);
 
             // get total count

--- a/tests/ModelControllerProjectionTest.php
+++ b/tests/ModelControllerProjectionTest.php
@@ -1,0 +1,90 @@
+<?php
+namespace Kyte\Test;
+
+use PHPUnit\Framework\TestCase;
+use Kyte\Mvc\Controller\ModelController;
+
+/**
+ * Unit tests for ModelController::resolveProjection (KYTE-#190) — the pure
+ * projection-resolution logic behind the generic X-Kyte-Fields wiring and the
+ * controller default-exclude (server-side deferral). No DB / request state.
+ */
+class ModelControllerProjectionTest extends TestCase
+{
+    /** @var array<string,mixed> */
+    private $struct = [
+        'id'           => ['type' => 'i'],
+        'name'         => ['type' => 's'],
+        'client'       => ['type' => 'i', 'fk' => ['model' => 'Client', 'field' => 'id']],
+        'body'         => ['type' => 'lt'],
+        'kyte_account' => ['type' => 'i'],
+        'date_created' => ['type' => 'i'],
+    ];
+
+    /** @var array<int,string> */
+    private $always = ['id', 'kyte_account', 'date_created'];
+
+    public function testNoHeaderNoExcludeReturnsNull(): void
+    {
+        // full row — historical behaviour preserved
+        $this->assertNull(ModelController::resolveProjection($this->struct, null, $this->always, []));
+    }
+
+    public function testEmptyHeaderReturnsNull(): void
+    {
+        $this->assertNull(ModelController::resolveProjection($this->struct, '   ', $this->always, []));
+    }
+
+    public function testHeaderProjectsRequestedPlusAlways(): void
+    {
+        $p = ModelController::resolveProjection($this->struct, 'name', $this->always, []);
+        $this->assertContains('name', $p);
+        $this->assertContains('id', $p);             // always-included
+        $this->assertContains('kyte_account', $p);
+        $this->assertNotContains('body', $p);        // large column not requested
+    }
+
+    public function testDottedFkPathContributesBaseColumn(): void
+    {
+        $p = ModelController::resolveProjection($this->struct, 'name,client.name', $this->always, []);
+        $this->assertContains('client', $p);         // base column of client.name
+        $this->assertNotContains('body', $p);
+    }
+
+    public function testUnknownFieldsDropped(): void
+    {
+        $p = ModelController::resolveProjection($this->struct, 'name,bogus,also.bad', $this->always, []);
+        $this->assertContains('name', $p);
+        $this->assertNotContains('bogus', $p);
+        $this->assertNotContains('also', $p);
+    }
+
+    public function testAllUnknownFieldsFallBackToNull(): void
+    {
+        // header present but nothing valid => full row, not an empty projection
+        $this->assertNull(ModelController::resolveProjection($this->struct, 'bogus,nope', $this->always, []));
+    }
+
+    public function testDefaultExcludeProjectsStructMinusExcludes(): void
+    {
+        $p = ModelController::resolveProjection($this->struct, null, $this->always, ['body']);
+        $this->assertNotContains('body', $p);        // excluded
+        $this->assertContains('name', $p);           // everything else present
+        $this->assertContains('id', $p);
+        $this->assertContains('client', $p);
+    }
+
+    public function testHeaderTakesPrecedenceOverDefaultExclude(): void
+    {
+        // a client that explicitly asks for `body` wins over the default exclude
+        $p = ModelController::resolveProjection($this->struct, 'body', $this->always, ['body']);
+        $this->assertContains('body', $p);
+    }
+
+    public function testNoDuplicateColumns(): void
+    {
+        // `id` is both always-included and requested — it must appear once
+        $p = ModelController::resolveProjection($this->struct, 'id,name', $this->always, []);
+        $this->assertSame(count($p), count(array_unique($p)));
+    }
+}


### PR DESCRIPTION
Makes column projection (P1 engine, #114/#115) available on **every** model endpoint via the generic controller, and retro-fits `KyteActivityLogController` as the first consumer (**slice 4**).

## Generic wiring (`ModelController`)
- **`resolveProjection()`** — pure/static, unit-testable — resolves the SELECT column list:
  - client **`X-Kyte-Fields`** header (opt-in include; a dotted FK path like `client.name` contributes its base column `client`) unioned with `projectionAlwaysInclude()`, **or**
  - a controller's **`defaultProjectionExclude()`** (server-side deferral = all struct columns minus excludes), **else** `null` (full row — historical behavior). A header naming nothing valid falls back to `null`.
- `projectionAlwaysInclude()`: id + account/audit (overridable, protects response hooks / FK expansion per the brainstorm's `alwaysInclude` decision).
- `get()` applies the projection via `Model::select()` before retrieve.
- **Opt-in + backward compatible:** no header + no controller exclude = `SELECT *`.

## Activity-log retrofit (slice 4)
`KyteActivityLogController::defaultProjectionExclude()` excludes the heavy LONGTEXT columns (`request_data`, `changes`) from **list** reads **at the query level** — they're no longer read from the DB for a list (superseding the #182 post-query `unset`, now removed). The detail fetch (by id) still returns them for decoding.

## Bonus
FK expansion in `getObject` iterates the *projected* response, so a projected-out FK is auto-skipped — a free N+1 reduction (full eager-load audit tracked in #340).

## Validation
- **`ModelControllerProjectionTest`** — 9 cases (header, dotted FK, unknown-field drop, all-unknown→null, default-exclude, header-precedence, dedupe).
- **Full unit suite green: 265 tests / 803 assertions** vs MariaDB 10.5; PHPStan clean.

Refs #190. Next: pagination guardrails, the #340 N+1 audit, and the kyte-api-js `KyteTable` `X-Kyte-Fields` one-liner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)