### PR TITLE
feat(190): fix generic-list FK-expansion N+1 via scoped eager-loading (#340)

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -26,6 +26,7 @@
       <file>tests/McpTokenControllerTest.php</file>
       <file>tests/McpTokenStrategyTest.php</file>
       <file>tests/ModelControllerProjectionTest.php</file>
+      <file>tests/ModelEagerLoadTest.php</file>
       <file>tests/ModelTest.php</file>
       <file>tests/PublishIntegrityTest.php</file>
       <file>tests/RefreshTokenStoreTest.php</file>

--- a/src/Core/Model.php
+++ b/src/Core/Model.php
@@ -30,6 +30,15 @@ class Model
 	private $eagerLoad = [];
 
 	/**
+	 * Optional per-relation scoping conditions applied to the batched eager-load
+	 * query (KYTE-#190 / #340), keyed by relation name. Each entry is a list of
+	 * ['field' => ..., 'value' => ...] AND-ed into the FK lookup so eager-loaded
+	 * rows are scoped identically to the lazy path (account/org isolation).
+	 * @var array<string,array<int,array<string,mixed>>>
+	 */
+	private $eagerLoadConditions = [];
+
+	/**
 	 * Column projection (KYTE-#190). When set to a non-empty array of column
 	 * names, retrieve() reads only those columns (plus `id`) instead of every
 	 * column — the mechanism for keeping large TEXT/BLOB columns out of list
@@ -58,11 +67,16 @@ class Model
 	 * @param string|array $relations Relationship name(s) - FK field names from model struct
 	 * @return self For method chaining
 	 */
-	public function with($relations) {
+	public function with($relations, $conditionsMap = []) {
 		if (is_string($relations)) {
 			$this->eagerLoad[] = $relations;
 		} elseif (is_array($relations)) {
 			$this->eagerLoad = array_merge($this->eagerLoad, $relations);
+		}
+		// Optional per-relation scoping conditions (account/org isolation), so
+		// the batched eager-load returns the same rows the lazy path would.
+		if (is_array($conditionsMap) && !empty($conditionsMap)) {
+			$this->eagerLoadConditions = array_merge($this->eagerLoadConditions, $conditionsMap);
 		}
 		return $this;  // Fluent interface for chaining
 	}
@@ -359,14 +373,21 @@ class Model
 				continue;
 			}
 
-			// Single query to load all related records
+			// Single query to load all related records — with the same account/
+			// org scoping the lazy path applies, so eager-loading can't surface
+			// cross-account/org FK rows (KYTE-#190 / #340).
 			$ids = array_unique($ids);
 			$idList = implode(',', array_map('intval', $ids));
-			$relatedData = \Kyte\Core\DBI::select(
-				$fkModel['name'],
-				null,
-				" WHERE `{$fk['field']}` IN ($idList)"
-			);
+			$sql = " WHERE `{$fk['field']}` IN ($idList)";
+			if (!empty($this->eagerLoadConditions[$relation])) {
+				foreach ($this->eagerLoadConditions[$relation] as $cond) {
+					if (isset($cond['field'], $cond['value'])) {
+						$escaped = \Kyte\Core\DBI::escape_string($cond['value']);
+						$sql .= " AND `{$cond['field']}` = '{$escaped}'";
+					}
+				}
+			}
+			$relatedData = \Kyte\Core\DBI::select($fkModel['name'], null, $sql);
 
 			// Index by FK field for O(1) lookup
 			$relatedMap = [];

--- a/src/Mvc/Controller/ModelController.php
+++ b/src/Mvc/Controller/ModelController.php
@@ -309,6 +309,68 @@ class ModelController
         return [];
     }
 
+    /**
+     * Account/org scoping conditions for a foreign-key lookup (KYTE-#190) — the
+     * single source of truth shared by the lazy FK expansion in getObject and
+     * the batched eager-load, so both scope identically. Returns null when the
+     * FK model needs no scoping (app-DB model without a userorg column,
+     * KyteAccount, or requireAccount off).
+     *
+     * @param array<string,mixed> $fk_model The referenced model definition
+     * @param array<string,mixed> $fk       The fk struct (model/field)
+     * @return array<int,array<string,mixed>>|null
+     */
+    protected function fkScopeConditions($fk_model, $fk)
+    {
+        if (!isset($fk_model['appId']) && $this->requireAccount && $fk['model'] !== 'KyteAccount') {
+            return [['field' => 'kyte_account', 'value' => $this->api->account->id]];
+        }
+        if ($this->requireAccount && $this->api->app !== null && $this->user !== null && $this->api->app->org_model !== null && $this->api->app->userorg_colname !== null && isset($fk_model['struct'][$this->api->app->userorg_colname])) {
+            return [['field' => $this->api->app->userorg_colname, 'value' => $this->user->{$this->api->app->userorg_colname}]];
+        }
+        return null;
+    }
+
+    /**
+     * Compute the FK relations to eager-load for a get() (KYTE-#190 / #340) so
+     * FK expansion is batched instead of N+1. Only relations that (a) will
+     * actually be expanded — getFKTables on, present in $projection when the
+     * read is projected — and (b) live in the SAME DB context as this model
+     * (app-DB vs control-DB) are eager-loaded; a cross-DB FK stays on the
+     * (DB-switching) lazy path. Returns a map of relation => scoping-conditions
+     * for Model::with(), scoped identically to the lazy path.
+     *
+     * @param array<int,string>|null $projection
+     * @return array<string,array<int,array<string,mixed>>|null>
+     */
+    protected function eagerLoadPlan($projection)
+    {
+        $plan = [];
+        if (!$this->getFKTables) {
+            return $plan;
+        }
+        $mainInApp = isset($this->model['appId']);
+        foreach ($this->model['struct'] as $key => $struct) {
+            if (!isset($struct['fk']['model'], $struct['fk']['field'])) {
+                continue;
+            }
+            if ($projection !== null && !in_array($key, $projection, true)) {
+                continue;
+            }
+            if (!defined($struct['fk']['model'])) {
+                continue;
+            }
+            $fk_model = constant($struct['fk']['model']);
+            // Same DB context only — a cross-DB FK needs a switch the batched
+            // query does not do, so leave it to the lazy path.
+            if (isset($fk_model['appId']) !== $mainInApp) {
+                continue;
+            }
+            $plan[$key] = $this->fkScopeConditions($fk_model, $struct['fk']);
+        }
+        return $plan;
+    }
+
     protected function getObject($obj) {
         try {
             $response = $obj->getAllParams();
@@ -375,12 +437,7 @@ class ModelController
                         $fk_model = constant($fk['model']);
                         $fk_obj = new \Kyte\Core\ModelObject($fk_model);
 
-                        $conditions = null;
-                        if (!isset($fk_model['appId']) && $this->requireAccount && $fk['model'] !== 'KyteAccount') {
-                            $conditions = [['field' => 'kyte_account', 'value' => $this->api->account->id]];
-                        } elseif ($this->requireAccount && $this->api->app !== null && $this->user !== null && $this->api->app->org_model !== null && $this->api->app->userorg_colname !== null && isset($fk_model['struct'][$this->api->app->userorg_colname])) {
-                            $conditions = [['field' => $this->api->app->userorg_colname, 'value' => $this->user->{$this->api->app->userorg_colname}]];
-                        }
+                        $conditions = $this->fkScopeConditions($fk_model, $fk);
 
                         if ($fk_obj->retrieve($fk['field'], $value, $conditions, null, true)) {
                             $value = $this->getObject($fk_obj); // Recursively get object for FK
@@ -797,6 +854,14 @@ class ModelController
             $objs = new \Kyte\Core\Model($this->model, $this->api->page_size, $this->api->page_num, $search_fields, $search_values);
             if ($projection !== null) {
                 $objs->select($projection);
+            }
+
+            // Eager-load FK relations (KYTE-#190 / #340) so FK expansion is one
+            // batched query per relation instead of N+1, using the same scoping
+            // and DB context as the lazy path.
+            $eagerPlan = $this->eagerLoadPlan($projection);
+            if (!empty($eagerPlan)) {
+                $objs->with(array_keys($eagerPlan), $eagerPlan);
             }
 
             // Pagination guardrail (KYTE-#190): an unbounded HTTP list (no page

--- a/tests/ModelEagerLoadTest.php
+++ b/tests/ModelEagerLoadTest.php
@@ -1,0 +1,107 @@
+<?php
+namespace Kyte\Test;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * KYTE-#190 / #340: batched FK eager-loading in Model::with()/eagerLoadRelations
+ * must (a) attach the related object for each row (fixing the N+1) and (b) apply
+ * the same account/org scoping the lazy path uses, so it can NEVER surface a
+ * cross-account FK row.
+ */
+class ModelEagerLoadTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        new \Kyte\Core\Api();
+        \Kyte\Core\DBI::dbInit(KYTE_DB_USERNAME, KYTE_DB_PASSWORD, KYTE_DB_HOST, KYTE_DB_DATABASE, KYTE_DB_CHARSET, 'InnoDB');
+
+        if (!defined('EagerParent')) {
+            define('EagerParent', [
+                'name' => 'EagerParent',
+                'struct' => [
+                    'id'           => ['type' => 'i', 'required' => true, 'pk' => true, 'size' => 11, 'date' => false],
+                    'name'         => ['type' => 's', 'required' => false, 'size' => 255, 'date' => false],
+                    'kyte_account' => ['type' => 'i', 'required' => false, 'size' => 11, 'unsigned' => true, 'date' => false],
+                    'created_by'   => ['type' => 'i', 'required' => false, 'date' => true],
+                    'date_created' => ['type' => 'i', 'required' => false, 'date' => true],
+                    'modified_by'  => ['type' => 'i', 'required' => false, 'date' => true],
+                    'date_modified' => ['type' => 'i', 'required' => false, 'date' => true],
+                    'deleted_by'   => ['type' => 'i', 'required' => false, 'date' => true],
+                    'date_deleted' => ['type' => 'i', 'required' => false, 'date' => true],
+                    'deleted'      => ['type' => 'i', 'required' => false, 'size' => 1, 'unsigned' => true, 'default' => 0, 'date' => false],
+                ],
+            ]);
+        }
+        if (!defined('EagerChild')) {
+            define('EagerChild', [
+                'name' => 'EagerChild',
+                'struct' => [
+                    'id'           => ['type' => 'i', 'required' => true, 'pk' => true, 'size' => 11, 'date' => false],
+                    'parent'       => ['type' => 'i', 'required' => false, 'size' => 11, 'unsigned' => true, 'date' => false, 'fk' => ['model' => 'EagerParent', 'field' => 'id']],
+                    'kyte_account' => ['type' => 'i', 'required' => false, 'size' => 11, 'unsigned' => true, 'date' => false],
+                    'created_by'   => ['type' => 'i', 'required' => false, 'date' => true],
+                    'date_created' => ['type' => 'i', 'required' => false, 'date' => true],
+                    'modified_by'  => ['type' => 'i', 'required' => false, 'date' => true],
+                    'date_modified' => ['type' => 'i', 'required' => false, 'date' => true],
+                    'deleted_by'   => ['type' => 'i', 'required' => false, 'date' => true],
+                    'date_deleted' => ['type' => 'i', 'required' => false, 'date' => true],
+                    'deleted'      => ['type' => 'i', 'required' => false, 'size' => 1, 'unsigned' => true, 'default' => 0, 'date' => false],
+                ],
+            ]);
+        }
+
+        \Kyte\Core\DBI::query('DROP TABLE IF EXISTS `EagerChild`');
+        \Kyte\Core\DBI::query('DROP TABLE IF EXISTS `EagerParent`');
+        \Kyte\Core\DBI::createTable(EagerParent);
+        \Kyte\Core\DBI::createTable(EagerChild);
+    }
+
+    public function testEagerLoadAttachesRelatedObjectForEachRow(): void
+    {
+        // Two parents + two children (account 1), each referencing a parent.
+        $pa = new \Kyte\Core\ModelObject(EagerParent);
+        $pa->create(['name' => 'Alpha', 'kyte_account' => 1]);
+        $pb = new \Kyte\Core\ModelObject(EagerParent);
+        $pb->create(['name' => 'Beta', 'kyte_account' => 1]);
+
+        $ca = new \Kyte\Core\ModelObject(EagerChild);
+        $ca->create(['parent' => $pa->id, 'kyte_account' => 1]);
+        $cb = new \Kyte\Core\ModelObject(EagerChild);
+        $cb->create(['parent' => $pb->id, 'kyte_account' => 1]);
+
+        $m = new \Kyte\Core\Model(EagerChild);
+        $m->with(['parent']);
+        $this->assertTrue($m->retrieve('kyte_account', 1, false, null, true));
+        $this->assertEquals(2, $m->count());
+
+        foreach ($m->objects as $child) {
+            $this->assertTrue(isset($child->parent_object), 'each child gets its parent eager-loaded');
+        }
+    }
+
+    public function testScopedEagerLoadDoesNotLeakCrossAccountParent(): void
+    {
+        // Parent belongs to account 2; a child in account 1 references it.
+        $p = new \Kyte\Core\ModelObject(EagerParent);
+        $p->create(['name' => 'Secret', 'kyte_account' => 2]);
+        $c = new \Kyte\Core\ModelObject(EagerChild);
+        $c->create(['parent' => $p->id, 'kyte_account' => 1]);
+
+        // With account-1 scoping, the account-2 parent must NOT be eager-loaded.
+        $scoped = new \Kyte\Core\Model(EagerChild);
+        $scoped->with(['parent'], ['parent' => [['field' => 'kyte_account', 'value' => 1]]]);
+        $this->assertTrue($scoped->retrieve('kyte_account', 1, false, null, true));
+        $child = $scoped->first();
+        $this->assertFalse(isset($child->parent_object), 'cross-account parent must NOT leak when scoped');
+
+        // Control: without scoping the batched load DOES pull it — proving the
+        // scoping conditions are what prevent the leak.
+        $unscoped = new \Kyte\Core\Model(EagerChild);
+        $unscoped->with(['parent']);
+        $this->assertTrue($unscoped->retrieve('kyte_account', 1, false, null, true));
+        $child2 = $unscoped->first();
+        $this->assertTrue(isset($child2->parent_object), 'unscoped eager-load loads the parent (control)');
+        $this->assertEquals('Secret', $child2->parent_object->getParam('name'));
+    }
+}


### PR DESCRIPTION
Closes **#340**. The audit confirmed the generic `ModelController::get()` path expands foreign keys **one-query-per-row (N+1)** — `getObject` lazily loads each row's FK, and nothing was calling `Model::with()`. The existing `eagerLoadRelations()` also had **two correctness gaps** that made naive enabling unsafe: **no account/org scoping** (the lazy path has it) and **no DB-context switch**.

## Fix
- **`ModelController::fkScopeConditions()`** — `getObject`'s FK scoping extracted into one shared helper, now used by **both** the lazy path and the eager-load, so they scope **identically** (account / userorg isolation).
- **`Model::with($relations, $conditionsMap)`** — accepts per-relation conditions; `eagerLoadRelations()` AND-s them into the batched `IN (...)` query, so an eager-loaded FK row can never surface cross-account/org.
- **`ModelController::get()` builds an `eagerLoadPlan()`** and calls `with()` — eager-loads only FKs that (a) will actually be expanded (`getFKTables` on; present in the projection when projected) and (b) live in the **same DB context** as the main model. A cross-DB FK stays on the (DB-switching) lazy path. The common **user-model → user-model list goes from N+1 to one batched query per relation.**

Backward compatible: same rows, same scoping — just batched. Projected-out FKs are skipped entirely.

## Validation (security-sensitive — tested hard)
`ModelEagerLoadTest`:
- eager-load attaches the related object for each row (N+1 fixed);
- **a scoped eager-load does NOT leak a cross-account parent**, while the unscoped control *does* — proving the scoping conditions are what block the leak.

**Full unit suite green: 268 tests / 821 assertions** vs MariaDB 10.5; PHPStan clean. All existing FK-expansion tests (McpModelTools etc.) still pass.

Closes #340. Refs #190, #171. Next: the kyte-api-js `KyteTable` `X-Kyte-Fields` one-liner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)