### PR TITLE
fix(190): projection safety — opt-in per controller + always-include FK columns

### DIFF
--- a/src/Mvc/Controller/ModelController.php
+++ b/src/Mvc/Controller/ModelController.php
@@ -289,11 +289,37 @@ class ModelController
      */
     protected function projectionAlwaysInclude()
     {
-        $always = ['id', 'kyte_account', 'created_by', 'date_created', 'modified_by', 'date_modified', 'deleted_by', 'date_deleted', 'deleted'];
-        $struct = $this->model['struct'];
-        return array_values(array_filter($always, function ($c) use ($struct) {
-            return isset($struct[$c]);
-        }));
+        return self::alwaysIncludeColumns($this->model['struct']);
+    }
+
+    /**
+     * Columns always kept in a projected read (KYTE-#190 decision C: "id + FK
+     * ids + audit"): id, account/audit columns, AND every foreign-key column.
+     *
+     * FK columns are always included so FK expansion (SESSION_RETURN_FK) still
+     * runs even when the client's X-Kyte-Fields omits them — controllers read
+     * expanded FK data in their response hooks (e.g. KytePage/KyteScript/Media
+     * build their S3 client from `$r['site']['region']`), and dropping the FK
+     * would break them. Trimming *inside* the expanded FK object is the separate
+     * nested-projection fast-follow (#332). Pure/static for unit testing.
+     *
+     * @param array<string,mixed> $struct Model struct (column => definition)
+     * @return array<int,string>
+     */
+    public static function alwaysIncludeColumns($struct)
+    {
+        $always = [];
+        foreach (['id', 'kyte_account', 'created_by', 'date_created', 'modified_by', 'date_modified', 'deleted_by', 'date_deleted', 'deleted'] as $c) {
+            if (isset($struct[$c])) {
+                $always[] = $c;
+            }
+        }
+        foreach ($struct as $key => $def) {
+            if (isset($def['fk']) && !in_array($key, $always, true)) {
+                $always[] = $key;
+            }
+        }
+        return array_values($always);
     }
 
     /**

--- a/src/Mvc/Controller/ModelController.php
+++ b/src/Mvc/Controller/ModelController.php
@@ -100,6 +100,14 @@ class ModelController
     protected $getExternalTables;
     protected $requireAuth;
     protected $requireAccount;
+    // Client-driven column projection (KYTE-#190) is OPT-IN per controller. A
+    // rich controller whose response hooks read columns the client didn't
+    // display (e.g. KytePage reads s3key / site.region to build S3 links) would
+    // break under a blind X-Kyte-Fields projection, so it is OFF by default.
+    // The generic/user-model path — and, later, the DB-driven controller_config
+    // flag — turns it on for models that are safe. The server-side
+    // defaultProjectionExclude() path is independent and always honoured.
+    protected $allowClientProjection = false;
     protected $failOnNull;
     protected $checkExisting;
     protected $existingThrowException;
@@ -867,11 +875,15 @@ class ModelController
             }
 
             // Column projection (KYTE-#190): resolve the SELECT column list from
-            // the client's X-Kyte-Fields header (opt-in) or a controller's
+            // the client's X-Kyte-Fields header — only when this controller
+            // opts in ($allowClientProjection) — or a controller's server-side
             // default-exclude set, else null (full row — historical behaviour).
+            $clientFields = ($this->allowClientProjection && isset($_SERVER['HTTP_X_KYTE_FIELDS']))
+                ? $_SERVER['HTTP_X_KYTE_FIELDS']
+                : null;
             $projection = self::resolveProjection(
                 $this->model['struct'],
-                isset($_SERVER['HTTP_X_KYTE_FIELDS']) ? $_SERVER['HTTP_X_KYTE_FIELDS'] : null,
+                $clientFields,
                 $this->projectionAlwaysInclude(),
                 $this->defaultProjectionExclude()
             );

--- a/tests/ModelControllerProjectionTest.php
+++ b/tests/ModelControllerProjectionTest.php
@@ -87,4 +87,34 @@ class ModelControllerProjectionTest extends TestCase
         $p = ModelController::resolveProjection($this->struct, 'id,name', $this->always, []);
         $this->assertSame(count($p), count(array_unique($p)));
     }
+
+    public function testAlwaysIncludeColumnsKeepsIdAuditAndForeignKeys(): void
+    {
+        // Decision C ("id + FK ids + audit"): FK columns must always be kept so
+        // FK expansion still runs for hooks that read expanded FK data (e.g.
+        // KytePage/KyteScript/Media read $r['site']['region']).
+        $always = ModelController::alwaysIncludeColumns($this->struct);
+        $this->assertContains('id', $always);
+        $this->assertContains('kyte_account', $always);   // account/audit
+        $this->assertContains('date_created', $always);
+        $this->assertContains('client', $always);          // FK column always kept
+        $this->assertNotContains('name', $always);         // plain column not auto-included
+        $this->assertNotContains('body', $always);         // large column not auto-included
+        $this->assertSame(count($always), count(array_unique($always)));
+    }
+
+    public function testProjectionKeepsForeignKeysSoExpansionStillRuns(): void
+    {
+        // End-to-end of the fix: a client projecting only `name` still gets the
+        // FK `client` back (via always-include), so FK expansion isn't dropped.
+        $p = ModelController::resolveProjection(
+            $this->struct,
+            'name',
+            ModelController::alwaysIncludeColumns($this->struct),
+            []
+        );
+        $this->assertContains('name', $p);
+        $this->assertContains('client', $p);   // FK preserved even though unrequested
+        $this->assertNotContains('body', $p);  // large column still trimmed
+    }
 }


### PR DESCRIPTION
**Found by end-to-end testing against Shipyard** — exactly what the integration test is for.

## The bug
The #117 generic projection wiring's `projectionAlwaysInclude()` kept `id` + audit but **not foreign-key columns** — I omitted the "**FK ids**" part of brainstorm decision C.

When a `KyteTable` doesn't *display* a FK column (e.g. Shipyard's site-detail `KytePage`/`KyteScript`/`Media` tables are already scoped to one site, so they show no `site` column), the client's `X-Kyte-Fields` omits `site` → the server projects it out → FK expansion (`SESSION_RETURN_FK`) never runs → `KytePage`/`KyteScript`/`Media` controllers, which build their S3 client from **`$r['site']['region']`**, get an empty region and throw **"region required for the s3 service" (HTTP 400)**.

## The fix
`alwaysIncludeColumns()` (new pure/static helper behind `projectionAlwaysInclude`) now always keeps **every FK column** in addition to id + audit. FK columns are small ints and were always expanded pre-#190, so this restores correct behavior while still trimming the large non-FK columns. Trimming *inside* the expanded FK object stays the #332 nested-projection fast-follow.

## Validation
- `ModelControllerProjectionTest`: `alwaysIncludeColumns` keeps id + audit + FK (not plain/large columns); projecting only a plain column still returns the FK.
- Suite green; PHPStan clean.

Refs #190, #117.

🤖 Generated with [Claude Code](https://claude.com/claude-code)