### PR TITLE
fix(190): eager-load leaked <fk>_object helpers into responses (breaks KytePage)

### DIFF
--- a/src/Mvc/Controller/ModelController.php
+++ b/src/Mvc/Controller/ModelController.php
@@ -371,10 +371,36 @@ class ModelController
         return $plan;
     }
 
+    /**
+     * Strip eager-load helper keys (`<fk>_object`) from a response row (KYTE-#190).
+     * Model::eagerLoadRelations attaches the fetched relation as a dynamic
+     * `<fk>_object` property for getObject() to consume — it is an internal
+     * expansion helper, not a response field. getAllParams() surfaces it, so
+     * left in the payload it duplicates the related row and, for relations whose
+     * columns carry binary data (e.g. bzip2-compressed section templates),
+     * produces invalid UTF-8 that makes json_encode fail. Only non-struct keys
+     * ending in `_object` are removed. Pure/static for unit testing.
+     *
+     * @param array<string,mixed> $response Row from getAllParams()
+     * @param array<string,mixed> $struct   Model struct
+     * @return array<string,mixed>
+     */
+    public static function stripEagerHelpers(array $response, $struct)
+    {
+        foreach (array_keys($response) as $rk) {
+            if (is_string($rk) && substr($rk, -7) === '_object' && !isset($struct[$rk])) {
+                unset($response[$rk]);
+            }
+        }
+        return $response;
+    }
+
     protected function getObject($obj) {
         try {
-            $response = $obj->getAllParams();
-    
+            // Strip eager-load `<fk>_object` helpers; the object property itself
+            // is kept so FK expansion below still uses the eager-loaded object.
+            $response = self::stripEagerHelpers($obj->getAllParams(), $obj->kyte_model['struct']);
+
             foreach ($response as $key => &$value) {
                 if (!isset($obj->kyte_model['struct'][$key])) {
                     continue; // Skip if key not found in struct

--- a/tests/ModelControllerProjectionTest.php
+++ b/tests/ModelControllerProjectionTest.php
@@ -87,4 +87,27 @@ class ModelControllerProjectionTest extends TestCase
         $p = ModelController::resolveProjection($this->struct, 'id,name', $this->always, []);
         $this->assertSame(count($p), count(array_unique($p)));
     }
+
+    public function testStripEagerHelpersRemovesObjectKeysButKeepsRealFields(): void
+    {
+        // Eager-load attaches `<fk>_object` helper props that getAllParams
+        // surfaces; they must not reach the response (KYTE-#190 — a bzip2
+        // section-template `<fk>_object` carries binary that breaks json_encode).
+        $struct = ['id' => [], 'parent' => ['fk' => []], 'name' => []];
+        $row = [
+            'id'            => 1,
+            'parent'        => 5,
+            'name'          => 'x',
+            'parent_object' => (object) ['name' => 'P'],   // eager helper (object)
+            'header_object' => "\xff\xfebinary",           // eager helper (binary)
+        ];
+        $out = ModelController::stripEagerHelpers($row, $struct);
+        $this->assertArrayHasKey('id', $out);
+        $this->assertArrayHasKey('parent', $out);          // real FK field kept
+        $this->assertArrayHasKey('name', $out);
+        $this->assertArrayNotHasKey('parent_object', $out); // helper stripped
+        $this->assertArrayNotHasKey('header_object', $out); // helper stripped
+        // the survivors must be JSON-encodable (the whole point)
+        $this->assertNotFalse(json_encode($out));
+    }
 }


### PR DESCRIPTION
A real regression in the merged N+1 eager-load (#119), **found by end-to-end testing** against Shipyard's site-detail page.

## Root cause
`Model::eagerLoadRelations` attaches each fetched relation as a dynamic **`<fk>_object`** property on the parent for `getObject()` to consume. But `getObject()` builds its response from `getAllParams()`, which **surfaces that dynamic property** — so the eager-loaded object leaked into the API payload.

- Most models: harmless duplicate data (valid JSON).
- **KytePage: fatal.** Its `header`/`footer` FKs are section templates whose content is **bzip2-compressed binary**, so `footer_object` carried raw bytes → **"Malformed UTF-8" → `json_encode` fails → 200 the client can't parse** ("Unable to load table data"). The lazy path never hit this (it expands FKs inline, no `_object` property).

Server-side diagnostics traced it exactly: `KytePage rows=50 json=FAIL:Malformed UTF-8`, `bad ... key=footer_object type=object`.

## Fix
`getObject()` strips non-struct `<fk>_object` keys from the response (new pure/static `ModelController::stripEagerHelpers`). The **object property is kept**, so FK expansion still uses the eager-loaded object — only the response copy is removed. Now byte-for-byte matches the lazy path.

## Validation
- **Verified on dev19: KytePage list loads 50 rows with eager-load ON.**
- Unit test for `stripEagerHelpers`; full suite green (**269 tests / 827 assertions**); PHPStan clean.

Closes the #119 regression. Refs #190.

🤖 Generated with [Claude Code](https://claude.com/claude-code)