### PR TITLE
feat(342): DB-driven controller_config — allow_projection flag (deliverable #1)

### DIFF
--- a/migrations/4.16.0_controller_config.sql
+++ b/migrations/4.16.0_controller_config.sql
@@ -1,0 +1,48 @@
+-- =========================================================================
+-- Kyte v4.16.0 - controller_config on DataModel + Controller (KYTE-#342)
+-- =========================================================================
+-- IMPORTANT: Backup your database before running this migration.
+--
+-- Adds a JSON `controller_config` column to DataModel (the baseline the generic
+-- controller path reads) and Controller (per-controller override), holding
+-- DB-driven, Shipyard-togglable controller behaviour flags. First flag:
+-- allow_projection (KYTE-#190 opt-in). See
+-- docs/design/db-driven-controller-config.md.
+--
+-- Nullable TEXT, no default -> a no-op for every existing row (empty config =
+-- global defaults). ADDITIVE / migration-first / inert on older code.
+--
+-- Portable idempotent add (MySQL 5.7/8 + MariaDB): MySQL has no
+-- `ADD COLUMN IF NOT EXISTS`, so guard with an information_schema check +
+-- prepared statement.
+-- =========================================================================
+
+-- DataModel.controller_config
+SET @col_exists := (
+    SELECT COUNT(*) FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME   = 'DataModel'
+      AND COLUMN_NAME  = 'controller_config'
+);
+SET @ddl := IF(@col_exists = 0,
+    'ALTER TABLE `DataModel` ADD COLUMN `controller_config` TEXT NULL DEFAULT NULL',
+    'DO 0'
+);
+PREPARE stmt FROM @ddl;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- Controller.controller_config
+SET @col_exists := (
+    SELECT COUNT(*) FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME   = 'Controller'
+      AND COLUMN_NAME  = 'controller_config'
+);
+SET @ddl := IF(@col_exists = 0,
+    'ALTER TABLE `Controller` ADD COLUMN `controller_config` TEXT NULL DEFAULT NULL',
+    'DO 0'
+);
+PREPARE stmt FROM @ddl;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;

--- a/src/Core/Api.php
+++ b/src/Core/Api.php
@@ -184,6 +184,11 @@ class Api
 		// stays unbounded. Both overridable per install in config.php.
 		'KYTE_MAX_PAGE_SIZE' => 100,
 		'KYTE_MAX_UNBOUNDED_ROWS' => 10000,
+		// DB-driven controller config (KYTE-#342). Global default for
+		// allow_projection (client-driven X-Kyte-Fields column projection).
+		// Off platform-wide; a model/controller opts in via controller_config,
+		// which overrides this. Overridable per install in config.php.
+		'KYTE_ALLOW_PROJECTION' => false,
 	];
 
 	/**
@@ -513,6 +518,12 @@ class Api
 				continue;
 			}
 			$model_definition['appId'] = $app->identifier;
+			// KYTE-#342: fold the model's controller_config JSON into the
+			// definition so it rides the model cache and is available on
+			// $this->model['controller_config'] for both the generic and custom
+			// controller paths (empty array when unset/invalid).
+			$cc = isset($object->controller_config) ? json_decode($object->controller_config, true) : null;
+			$model_definition['controller_config'] = is_array($cc) ? $cc : [];
 			$modelDefs[$model_definition['name']] = $model_definition;
 			if (!defined($model_definition['name'])) {
 				define($model_definition['name'], $model_definition);

--- a/src/Mvc/Controller/AppModelWrapperController.php
+++ b/src/Mvc/Controller/AppModelWrapperController.php
@@ -32,6 +32,11 @@ class AppModelWrapperController extends ModelController
         // specify model of this wrapper controller
         $this->model = constant($appModel->name);
 
+        // KYTE-#342: the user model is bound here (not in shipyard_init), so
+        // re-apply the DB-driven controller_config now that $this->model —
+        // and its controller_config — is available (e.g. allow_projection).
+        $this->applyControllerConfig();
+
         \Kyte\Core\Api::dbappconnect($this->api->app->db_name, $this->api->app->db_username, $this->api->app->db_password);
     }
 

--- a/src/Mvc/Controller/ModelController.php
+++ b/src/Mvc/Controller/ModelController.php
@@ -198,6 +198,13 @@ class ModelController
         
         $this->shipyard_init();
 
+        // KYTE-#342: apply DB-driven controller_config (before hook_init so a
+        // hand-written controller's hook_init can still override). Custom
+        // controllers bind $this->model in shipyard_init, so it is set here;
+        // the generic AppModelWrapperController binds it later in hook_init and
+        // re-applies there.
+        $this->applyControllerConfig();
+
         $this->hook_init();
 
         // Anonymous app-context (JWT-mode public access via AppContextStrategy).
@@ -235,6 +242,52 @@ class ModelController
             throw new \Kyte\Exception\SessionException("Unauthorized API request.");
         }
         $this->hook_auth();
+    }
+
+    /**
+     * Resolve the effective controller_config (KYTE-#342), most-specific wins:
+     * global defaults → DataModel baseline → Controller-row override. Pure/static
+     * for unit testing.
+     *
+     * @param array<string,mixed>      $global Platform defaults
+     * @param array<string,mixed>|null $model  DataModel controller_config
+     * @param array<string,mixed>|null $ctrl   Controller-row controller_config
+     * @return array<string,mixed>
+     */
+    public static function resolveControllerConfig(array $global, $model, $ctrl)
+    {
+        $effective = $global;
+        if (is_array($model)) {
+            $effective = array_merge($effective, $model);
+        }
+        if (is_array($ctrl)) {
+            $effective = array_merge($effective, $ctrl);
+        }
+        return $effective;
+    }
+
+    /**
+     * Apply the resolved controller_config to this controller's behaviour flags
+     * (KYTE-#342). Currently sets $allowClientProjection from `allow_projection`
+     * (global default KYTE_ALLOW_PROJECTION, overridden by the model's
+     * controller_config). Safe to call more than once and before the model is
+     * bound — it no-ops until $this->model['controller_config'] exists, so the
+     * generic AppModelWrapperController can re-apply after it binds the model.
+     * The remaining hook_init flags (require_account, expand_fk, …) migrate here
+     * over time. The Controller-row override layer is a fast-follow.
+     */
+    protected function applyControllerConfig()
+    {
+        $global = ['allow_projection' => (defined('KYTE_ALLOW_PROJECTION') ? (bool)KYTE_ALLOW_PROJECTION : false)];
+        $modelCfg = (is_array($this->model) && isset($this->model['controller_config']) && is_array($this->model['controller_config']))
+            ? $this->model['controller_config']
+            : null;
+
+        $effective = self::resolveControllerConfig($global, $modelCfg, null);
+
+        if (array_key_exists('allow_projection', $effective)) {
+            $this->allowClientProjection = (bool)$effective['allow_projection'];
+        }
     }
 
     /**

--- a/src/Mvc/Model/Controller.php
+++ b/src/Mvc/Model/Controller.php
@@ -39,6 +39,14 @@ $Controller = [
 			'date'		=> false,
 		],
 
+		// KYTE-#342: per-controller JSON behaviour config; overrides the
+		// DataModel baseline. See docs/design/db-driven-controller-config.md.
+		'controller_config'		=> [
+			'type'		=> 't',
+			'required'	=> false,
+			'date'		=> false,
+		],
+
 		'application'	=> [
 			'type'		=> 'i',
 			'required'	=> false,

--- a/src/Mvc/Model/DataModel.php
+++ b/src/Mvc/Model/DataModel.php
@@ -16,6 +16,15 @@ $DataModel = [
 			'date'		=> false,
 		],
 
+		// KYTE-#342: JSON controller behaviour config (baseline for the generic
+		// controller path; inheritable default for custom controllers). First
+		// flag: allow_projection. See docs/design/db-driven-controller-config.md.
+		'controller_config'		=> [
+			'type'		=> 't',
+			'required'	=> false,
+			'date'		=> false,
+		],
+
 		// 'get_request'	=> [
 		// 	'type'		=> 'i',
 		// 	'required'	=> false,

--- a/tests/ModelControllerProjectionTest.php
+++ b/tests/ModelControllerProjectionTest.php
@@ -118,6 +118,34 @@ class ModelControllerProjectionTest extends TestCase
         $this->assertNotContains('body', $p);  // large column still trimmed
     }
 
+    public function testResolveControllerConfigMostSpecificWins(): void
+    {
+        // KYTE-#342: global default -> DataModel baseline -> Controller override.
+        $global = ['allow_projection' => false];
+
+        // no overrides -> global
+        $this->assertSame(
+            ['allow_projection' => false],
+            ModelController::resolveControllerConfig($global, null, null)
+        );
+        // model baseline turns it on
+        $this->assertTrue(
+            ModelController::resolveControllerConfig($global, ['allow_projection' => true], null)['allow_projection']
+        );
+        // controller override wins over the model baseline
+        $this->assertFalse(
+            ModelController::resolveControllerConfig($global, ['allow_projection' => true], ['allow_projection' => false])['allow_projection']
+        );
+        // unrelated keys merge without clobbering
+        $merged = ModelController::resolveControllerConfig(
+            ['allow_projection' => false, 'require_account' => true],
+            ['allow_projection' => true],
+            null
+        );
+        $this->assertTrue($merged['allow_projection']);
+        $this->assertTrue($merged['require_account']);
+    }
+
     public function testStripEagerHelpersRemovesObjectKeysButKeepsRealFields(): void
     {
         // Eager-load attaches `<fk>_object` helper props that getAllParams


### PR DESCRIPTION
First deliverable of **KYTE-#342** (DB-driven controller config): turns the #190 client-projection opt-in (`$allowClientProjection`, until now a hardcoded `false`) into a **DB-driven, per-model value** — the on-ramp for migrating `hook_init` controller behavior into Shipyard-togglable flags.

## What
- **Schema:** `controller_config` TEXT (JSON) on **DataModel** (baseline for the generic path) + **Controller** (per-controller override). Migration `4.16.0_controller_config.sql` (portable idempotent add, MySQL + MariaDB).
- **Global default** `KYTE_ALLOW_PROJECTION => false` in the `Api` defaults map.
- **`Api::loadAppModels`** folds the model's `controller_config` into the cached model definition → available as `$this->model['controller_config']` everywhere, no extra query (rides the 1h model cache; a config edit flushes it via `DataModelController`'s existing `clearModelCache` on update).
- **Resolution:** `ModelController::resolveControllerConfig()` (pure/static) merges `global → DataModel → Controller`, most-specific wins. `applyControllerConfig()` reads it and sets `$allowClientProjection` — called after `shipyard_init` (custom controllers) and at the end of `AppModelWrapperController::hook_init` (the generic path binds the model there), **before** `hook_init` so hand-written overrides still win.

A plain user model opts into projection with `controller_config={"allow_projection":true}`; rich/framework controllers stay off (safe).

## Scope
Only `allow_projection` is wired now. The other `hook_init` flags (`require_account`, `expand_fk`, …) and the **Controller-level override layer** are documented fast-follows. The **Shipyard model-settings toggle** that writes `controller_config` is a separate kyte-shipyard PR.

## Validation
- `resolveControllerConfig` unit test (precedence + non-clobbering merge).
- Full suite green (**272 tests / 842 assertions**); PHPStan clean.

Refs #342, #190. See `docs/design/db-driven-controller-config.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)